### PR TITLE
Feature/xapi spec conformance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ bin/vault_password
 .team
 group_vars/
 k3d-storage/
+
+# Mac OS
+.DS_Store
+
+# VSCode
+.vscode
+.devcontainer

--- a/src/ralph/api/forwarding.py
+++ b/src/ralph/api/forwarding.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from typing import List, Literal, Union
 
 from httpx import AsyncClient, AsyncHTTPTransport, HTTPStatusError, RequestError
+from starlette.datastructures import Headers
 
 from ..conf import XapiForwardingConfigurationSettings, settings
 
@@ -33,7 +34,9 @@ def get_active_xapi_forwardings() -> List[XapiForwardingConfigurationSettings]:
 
 
 async def forward_xapi_statements(
-    statements: Union[dict, List[dict]], method: Literal["post", "put"]
+    statements: Union[dict, List[dict]],
+    method: Literal["post", "put"],
+    headers: Union[dict, Headers],
 ) -> None:
     """Forward xAPI statements."""
     for forwarding in get_active_xapi_forwardings():
@@ -46,6 +49,7 @@ async def forward_xapi_statements(
                     json=statements,
                     auth=(forwarding.basic_username, forwarding.basic_password),
                     timeout=forwarding.timeout,
+                    headers=headers,
                 )
                 req.raise_for_status()
                 msg = "Forwarded %s statements to %s with success."

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -11,6 +11,7 @@ from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    Header,
     HTTPException,
     Query,
     Request,
@@ -457,6 +458,7 @@ async def put(
     ],
     statement: LaxStatement,
     background_tasks: BackgroundTasks,
+    x_experience_api_version: Annotated[str | None, Header()],
     statement_id: UUID = Query(alias="statementId"),
     _=Depends(strict_query_params),
 ) -> None:
@@ -481,7 +483,10 @@ async def put(
 
     if get_active_xapi_forwardings():
         background_tasks.add_task(
-            forward_xapi_statements, statement_as_dict, method="put"
+            forward_xapi_statements,
+            statement_as_dict,
+            method="put",
+            headers={"X-Experience-API-Version": x_experience_api_version},
         )
 
     # Finish enriching statements after forwarding
@@ -547,6 +552,7 @@ async def post(
     ],
     statements: Union[LaxStatement, List[LaxStatement]],
     background_tasks: BackgroundTasks,
+    x_experience_api_version: Annotated[str | None, Header()],
     response: Response,
     _=Depends(strict_query_params),
 ) -> Union[List, None]:
@@ -581,7 +587,10 @@ async def post(
     # Forward statements
     if get_active_xapi_forwardings():
         background_tasks.add_task(
-            forward_xapi_statements, list(statements_dict.values()), method="post"
+            forward_xapi_statements,
+            list(statements_dict.values()),
+            method="post",
+            headers={"X-Experience-API-Version": x_experience_api_version},
         )
 
     try:

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -145,6 +145,8 @@ def strict_query_params(request: Request) -> None:
 
 @router.get("")
 @router.get("/")
+@router.head("")
+@router.head("/")
 async def get(  # noqa: PLR0913
     request: Request,
     current_user: Annotated[

--- a/src/ralph/api/routers/statements.py
+++ b/src/ralph/api/routers/statements.py
@@ -147,7 +147,7 @@ def strict_query_params(request: Request) -> None:
 @router.get("/")
 @router.head("")
 @router.head("/")
-async def get(  # noqa: PLR0913
+async def get(  # noqa: PLR0912, PLR0913
     request: Request,
     current_user: Annotated[
         AuthenticatedUser,
@@ -447,6 +447,15 @@ async def get(  # noqa: PLR0913
                 ).geturl(),
             }
         )
+
+    # If the request was done with a statement Id, we return the statement
+    if statement_id:
+        if not query_result.statements:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Statement not found",
+            )
+        return query_result.statements[0]
 
     return {**response, "statements": query_result.statements}
 

--- a/src/ralph/api/routers/xapi.py
+++ b/src/ralph/api/routers/xapi.py
@@ -1,0 +1,34 @@
+"""API routes related to other routes of the xAPI standard."""
+
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ralph.conf import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/xAPI")
+
+
+@router.get("/about")
+async def about():
+    """Return information about this LRS, including the xAPI version supported."""
+    return JSONResponse(
+        {
+            "version": settings.XAPI_VERSIONS_SUPPORTED,
+            "extensions": {
+                "xapi": {
+                    "statements": {
+                        "name": "Statements",
+                        "methods": ["GET", "POST", "PUT", "HEAD"],
+                        "endpoint": "/xAPI/statements",
+                        "description": (
+                            "Endpoint to submit and retrieve XAPI statements."
+                        ),
+                    }
+                }
+            },
+        }
+    )

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -215,6 +215,8 @@ class Settings(BaseSettings):
     SENTRY_IGNORE_HEALTH_CHECKS: bool = False
     SENTRY_LRS_TRACES_SAMPLE_RATE: float = 1.0
     XAPI_FORWARDINGS: List[XapiForwardingConfigurationSettings] = []
+    XAPI_VERSIONS_SUPPORTED: List[str] = ["1.0.3"]
+    XAPI_VERSION_FALLBACK: str = "1.0.3"
 
     @property
     def APP_DIR(self) -> Path:

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -9,14 +9,18 @@ from rfc3987 import parse
 from ralph.conf import NonEmptyStrictStr
 
 
-class IRI(RootModel[Union["IRI", str]]):
-    """Pydantic custom data type validating RFC 3987 IRIs."""
+class ResourceIdentifier(RootModel[Union[str]]):
+    """Pydantic custom data type for Resource Identifiers."""
 
     def __hash__(self):  # noqa: D105
         return hash(str(self.root))
 
     def __str__(self):  # noqa: D105
         return str(self.root)
+
+
+class IRI(ResourceIdentifier):
+    """Pydantic custom data type validating RFC 3987 IRIs."""
 
     @model_validator(mode="before")
     @classmethod
@@ -26,14 +30,8 @@ class IRI(RootModel[Union["IRI", str]]):
         return str(iri)
 
 
-class URI(RootModel[Union["URI", str]]):
+class URI(ResourceIdentifier):
     """Pydantic custom data type validating RFC 3987 URIs."""
-
-    def __hash__(self):  # noqa: D105
-        return hash(str(self.root))
-
-    def __str__(self):  # noqa: D105
-        return str(self.root)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -26,6 +26,23 @@ class IRI(RootModel[Union["IRI", str]]):
         return str(iri)
 
 
+class URI(RootModel[Union["URI", str]]):
+    """Pydantic custom data type validating RFC 3987 URIs."""
+
+    def __hash__(self):  # noqa: D105
+        return hash(str(self.root))
+
+    def __str__(self):  # noqa: D105
+        return str(self.root)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_uri(cls, uri):
+        """Check whether the provided URI is a valid RFC 3987 URI."""
+        parse(str(uri), rule="URI")
+        return str(uri)
+
+
 class LanguageTag(RootModel[Union[str, "LanguageTag"]]):
     """Pydantic custom data type validating RFC 5646 Language tags."""
 

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -56,7 +56,7 @@ class BaseXapiIdentifiedGroup(BaseXapiGroupCommonProperties):
         member (list): Consist of a list of the members of this Group.
     """
 
-    member: Optional[List[BaseXapiAgent]]
+    member: Optional[List[BaseXapiAgent]] = None
 
 
 class BaseXapiIdentifiedGroupWithMbox(BaseXapiIdentifiedGroup, BaseXapiMboxIFI):

--- a/src/ralph/models/xapi/base/ifi.py
+++ b/src/ralph/models/xapi/base/ifi.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 from ralph.conf import NonEmptyStrictStr
 
 from ..config import BaseModelWithConfig
-from .common import IRI, MailtoEmail
+from .common import IRI, URI, MailtoEmail
 
 
 class BaseXapiAccount(BaseModelWithConfig):
@@ -48,7 +48,7 @@ class BaseXapiOpenIdIFI(BaseModelWithConfig):
         openid (URI): Consists of an openID that uniquely identifies the Agent.
     """
 
-    openid: str
+    openid: URI
 
 
 class BaseXapiAccountIFI(BaseModelWithConfig):

--- a/tests/api/auth/test_oidc.py
+++ b/tests/api/auth/test_oidc.py
@@ -40,7 +40,7 @@ async def test_api_auth_oidc_get_whoami_valid(
     assert response.status_code == 200
     assert len(response.json().keys()) == 2
     assert response.json()["agent"] == {
-        "openid": "https://iss.example.com/123|oidc",
+        "openid": "https://iss.example.com/123_oidc",
         "objectType": "Agent",
     }
     assert TypeAdapter(BaseXapiAgentWithOpenId).validate_python(

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,3 @@
+from ..fixtures.statements import (
+    insert_statements_and_monkeypatch_backend,  # noqa: F401
+)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,3 +1,1 @@
-from ..fixtures.statements import (
-    insert_statements_and_monkeypatch_backend,  # noqa: F401
-)
+from ..fixtures.statements import insert_statements_and_monkeypatch_backend  #noqa: F401

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,1 +1,3 @@
-from ..fixtures.statements import insert_statements_and_monkeypatch_backend  #noqa: F401
+from ..fixtures.statements import (
+    insert_statements_and_monkeypatch_backend,  # noqa: F401
+)

--- a/tests/api/test_forwarding.py
+++ b/tests/api/test_forwarding.py
@@ -159,7 +159,9 @@ async def test_api_forwarding_forward_xapi_statements_with_successful_request(
 
     caplog.clear()
     with caplog.at_level(logging.DEBUG):
-        await forward_xapi_statements(statements, method="post")
+        await forward_xapi_statements(
+            statements, method="post", headers={"X-Experience-API-Version": "1.0.3"}
+        )
 
     assert [
         f"Forwarded {len(statements)} statements to {str(forwarding.url)} with success."
@@ -204,7 +206,9 @@ async def test_api_forwarding_forward_xapi_statements_with_unsuccessful_request(
 
     caplog.clear()
     with caplog.at_level(logging.ERROR):
-        await forward_xapi_statements(statements, method="post")
+        await forward_xapi_statements(
+            statements, method="post", headers={"X-Experience-API-Version": "1.0.3"}
+        )
 
     assert ["Failed to forward xAPI statements. Failure during request."] == [
         message

--- a/tests/api/test_middlewares.py
+++ b/tests/api/test_middlewares.py
@@ -1,0 +1,66 @@
+"""Tests for middlewares of the Ralph API."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from ralph.api import app
+
+
+@pytest.mark.anyio
+async def test_x_experience_api_version_header(
+    insert_statements_and_monkeypatch_backend, basic_auth_credentials
+):
+    """
+    Test X-Experience-API-Version header is checked in request and included in response.
+    """
+    statements = [
+        {
+            "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
+            "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
+        },
+        {
+            "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
+            "timestamp": datetime.now().isoformat(),
+        },
+    ]
+
+    insert_statements_and_monkeypatch_backend(statements)
+
+    async with AsyncClient(
+        app=app,
+        base_url="http://testserver",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    ) as client:
+        # Check for 400 status code when X-Experience-API-Version header is not included
+        response = await client.get(
+            "/xAPI/statements/",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Missing X-Experience-API-Version header"}
+        assert "X-Experience-API-Version" in response.headers
+        assert response.headers["X-Experience-API-Version"] == "1.0.3"
+
+        # Check that X-Experience-API-Version header is included in response
+        response = await client.get(
+            "/xAPI/statements/",
+            headers={"X-Experience-API-Version": "1.0.3"},
+        )
+
+        assert response.status_code == 200
+        assert "X-Experience-API-Version" in response.headers
+        assert response.headers["X-Experience-API-Version"] == "1.0.3"
+
+        # Check for 400 status code when X-Experience-API-Version header
+        # is included but unsupported
+        response = await client.get(
+            "/xAPI/statements/",
+            headers={"X-Experience-API-Version": "1.0.4"},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid X-Experience-API-Version header"}
+        assert "X-Experience-API-Version" in response.headers
+        assert response.headers["X-Experience-API-Version"] == "1.0.3"

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -6,124 +6,16 @@ from urllib.parse import parse_qs, quote_plus, urlparse
 
 import pytest
 import responses
-from elasticsearch.helpers import bulk
 
 from ralph.api.auth.basic import get_basic_auth_user
-from ralph.backends.data.base import BaseOperationType
-from ralph.backends.data.clickhouse import ClickHouseDataBackend
-from ralph.backends.data.mongo import MongoDataBackend
 from ralph.conf import AuthBackend
 from ralph.exceptions import BackendException
 
-from tests.fixtures.backends import (
-    CLICKHOUSE_TEST_DATABASE,
-    CLICKHOUSE_TEST_HOST,
-    CLICKHOUSE_TEST_PORT,
-    CLICKHOUSE_TEST_TABLE_NAME,
-    ES_TEST_INDEX,
-    MONGO_TEST_COLLECTION,
-    MONGO_TEST_DATABASE,
-    get_async_es_test_backend,
-    get_async_mongo_test_backend,
-    get_clickhouse_test_backend,
-    get_es_test_backend,
-    get_mongo_test_backend,
-)
+from tests.fixtures.backends import get_es_test_backend
 
 from ..fixtures.auth import AUDIENCE, ISSUER_URI, mock_basic_auth_user, mock_oidc_user
+from ..fixtures.statements import insert_es_statements
 from ..helpers import mock_activity, mock_agent
-
-
-def insert_es_statements(es_client, statements, index=ES_TEST_INDEX):
-    """Insert a bunch of example statements into Elasticsearch for testing."""
-    bulk(
-        es_client,
-        [
-            {
-                "_index": index,
-                "_id": statement["id"],
-                "_op_type": "index",
-                "_source": statement,
-            }
-            for statement in statements
-        ],
-    )
-    es_client.indices.refresh()
-
-
-def insert_mongo_statements(mongo_client, statements, collection):
-    """Insert a bunch of example statements into MongoDB for testing."""
-    database = getattr(mongo_client, MONGO_TEST_DATABASE)
-    collection = getattr(database, collection)
-    collection.insert_many(
-        list(
-            MongoDataBackend.to_documents(
-                data=statements,
-                ignore_errors=True,
-                operation_type=BaseOperationType.CREATE,
-            )
-        )
-    )
-
-
-def insert_clickhouse_statements(statements, table):
-    """Insert a bunch of example statements into ClickHouse for testing."""
-    settings = ClickHouseDataBackend.settings_class(
-        HOST=CLICKHOUSE_TEST_HOST,
-        PORT=CLICKHOUSE_TEST_PORT,
-        DATABASE=CLICKHOUSE_TEST_DATABASE,
-        EVENT_TABLE_NAME=CLICKHOUSE_TEST_TABLE_NAME,
-    )
-    backend = ClickHouseDataBackend(settings=settings)
-    success = backend.write(statements, target=table)
-    assert success == len(statements)
-
-
-@pytest.fixture(params=["async_es", "async_mongo", "es", "mongo", "clickhouse"])
-def insert_statements_and_monkeypatch_backend(
-    request, es_custom, mongo_custom, clickhouse_custom, monkeypatch
-):
-    """(Security) Return a function that inserts statements into each backend."""
-
-    def _insert_statements_and_monkeypatch_backend(statements, target=None):
-        """Insert statements once into each backend."""
-        backend_client_class_path = "ralph.api.routers.statements.BACKEND_CLIENT"
-        if request.param == "async_es":
-            target = target if target else ES_TEST_INDEX
-            client = es_custom(index=target)
-            insert_es_statements(client, statements, target)
-            monkeypatch.setattr(backend_client_class_path, get_async_es_test_backend())
-            return
-        if request.param == "async_mongo":
-            target = target if target else MONGO_TEST_COLLECTION
-            client = mongo_custom(collection=target)
-            insert_mongo_statements(client, statements, target)
-            monkeypatch.setattr(
-                backend_client_class_path, get_async_mongo_test_backend()
-            )
-            return
-        if request.param == "es":
-            target = target if target else ES_TEST_INDEX
-            client = es_custom(index=target)
-            insert_es_statements(client, statements, target)
-            monkeypatch.setattr(backend_client_class_path, get_es_test_backend())
-            return
-        if request.param == "mongo":
-            target = target if target else MONGO_TEST_COLLECTION
-            client = mongo_custom(collection=target)
-            insert_mongo_statements(client, statements, target)
-            monkeypatch.setattr(backend_client_class_path, get_mongo_test_backend())
-            return
-        if request.param == "clickhouse":
-            target = target if target else CLICKHOUSE_TEST_TABLE_NAME
-            _ = clickhouse_custom(event_table_name=target)
-            insert_clickhouse_statements(statements, target)
-            monkeypatch.setattr(
-                backend_client_class_path, get_clickhouse_test_backend()
-            )
-            return
-
-    return _insert_statements_and_monkeypatch_backend
 
 
 @pytest.mark.anyio

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -247,7 +247,7 @@ async def test_api_statements_get_mine(
         "/xAPI/statements/?mine=BigBoat",
         headers={"Authorization": f"Basic {credentials_1_bis}"},
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 @pytest.mark.anyio
@@ -788,12 +788,12 @@ async def test_api_statements_get_invalid_query_parameters(
         "detail": "The following parameter is not allowed: `mamamia`"
     }
 
-    # Check for 422 status code when a negative limit parameter is provided
+    # Check for 400 status code when a negative limit parameter is provided
     response = await client.get(
         "/xAPI/statements/?limit=-1",
         headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
 
     # Check for 400 status code when both statementId and voidedStatementId are provided
     response = await client.get(

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -782,7 +782,7 @@ async def test_api_statements_get_scopes(  # noqa: PLR0913
             AUDIENCE,
         )
 
-        sub = "123|oidc"
+        sub = "123_oidc"
         iss = "https://iss.example.com"
         agent = {"openid": f"{iss}/{sub}"}
         oidc_token = mock_oidc_user(sub=sub, scopes=scopes)

--- a/tests/api/test_statements_get.py
+++ b/tests/api/test_statements_get.py
@@ -126,13 +126,13 @@ async def test_api_statements_get_mine(
     assert response.status_code == 200
     assert response.json() == {"statements": [statements[0]]}
 
-    # Fetch "mine" by id with a single forbidden statement : Return empty list
+    # Fetch "mine" by id with a single forbidden statement : Return 404 not found
     response = await client.get(
         f"/xAPI/statements/?statementId={statements[1]['id']}&mine=True",
         headers={"Authorization": f"Basic {credentials_1_bis}"},
     )
-    assert response.status_code == 200
-    assert response.json() == {"statements": []}
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Statement not found"}
 
     # Check that invalid parameters returns an error
     response = await client.get(
@@ -282,7 +282,7 @@ async def test_api_statements_get_by_statement_id(
     )
 
     assert response.status_code == 200
-    assert response.json() == {"statements": [statements[1]]}
+    assert response.json() == statements[1]
 
 
 @pytest.mark.anyio
@@ -631,8 +631,8 @@ async def test_api_statements_get_with_no_matching_statement(
         headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
 
-    assert response.status_code == 200
-    assert response.json() == {"statements": []}
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Statement not found"}
 
 
 @pytest.mark.anyio

--- a/tests/api/test_statements_head.py
+++ b/tests/api/test_statements_head.py
@@ -1,0 +1,177 @@
+"""Tests for the HEAD statements endpoint of the Ralph API."""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from ralph.exceptions import BackendException
+
+from tests.fixtures.backends import get_es_test_backend
+
+from ..helpers import mock_activity, mock_agent
+
+
+@pytest.mark.anyio
+async def test_api_statements_head(
+    client, insert_statements_and_monkeypatch_backend, basic_auth_credentials
+):
+    """Test the head statements API route without any filters set up."""
+
+    statements = [
+        {
+            "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
+            "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
+        },
+        {
+            "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
+            "timestamp": datetime.now().isoformat(),
+        },
+    ]
+    insert_statements_and_monkeypatch_backend(statements)
+
+    # Confirm that calling this with and without the trailing slash both work
+    for path in ("/xAPI/statements", "/xAPI/statements/"):
+        response = await client.head(
+            path, headers={"Authorization": f"Basic {basic_auth_credentials}"}
+        )
+
+        assert response.status_code == 200
+        assert len(response.content) == 0
+
+
+@pytest.mark.anyio
+async def test_api_statements_head_by_statement_id(
+    client, insert_statements_and_monkeypatch_backend, basic_auth_credentials
+):
+    """Test the head statements API route given a "statementId" query parameter."""
+
+    statements = [
+        {
+            "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
+            "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
+        },
+        {
+            "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
+            "timestamp": datetime.now().isoformat(),
+        },
+    ]
+
+    insert_statements_and_monkeypatch_backend(statements)
+
+    response = await client.head(
+        f"/xAPI/statements/?statementId={statements[1]['id']}",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+
+    assert response.status_code == 200
+    assert len(response.content) == 0
+
+
+@pytest.mark.anyio
+async def test_api_statements_head_with_no_matching_statement(
+    client, insert_statements_and_monkeypatch_backend, basic_auth_credentials
+):
+    """
+    Test the head statements API route, given a query yielding no matching statement.
+    """
+
+    statements = [
+        {
+            "id": "be67b160-d958-4f51-b8b8-1892002dbac6",
+            "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
+        },
+        {
+            "id": "72c81e98-1763-4730-8cfc-f5ab34f1bad2",
+            "timestamp": datetime.now().isoformat(),
+        },
+    ]
+    insert_statements_and_monkeypatch_backend(statements)
+
+    response = await client.head(
+        "/xAPI/statements/?statementId=66c81e98-1763-4730-8cfc-f5ab34f1bad5",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+
+    assert response.status_code == 200
+    assert len(response.content) == 0
+
+
+@pytest.mark.anyio
+async def test_api_statements_head_with_database_query_failure(
+    client, basic_auth_credentials, monkeypatch
+):
+    """Test the head statements API route, given a query raising a BackendException."""
+
+    def mock_query_statements(*_, **__):
+        """Mocks the BACKEND_CLIENT.query_statements method."""
+        raise BackendException()
+
+    monkeypatch.setattr(
+        "ralph.api.routers.statements.BACKEND_CLIENT.query_statements",
+        mock_query_statements,
+    )
+
+    response = await client.head(
+        "/xAPI/statements/",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+    assert response.status_code == 500
+    assert len(response.content) == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("id_param", ["statementId", "voidedStatementId"])
+async def test_api_statements_head_invalid_query_parameters(
+    client, monkeypatch, es, basic_auth_credentials, id_param
+):
+    """Test error response for invalid query parameters."""
+
+    id_1 = "be67b160-d958-4f51-b8b8-1892002dbac6"
+    id_2 = "66c81e98-1763-4730-8cfc-f5ab34f1bad5"
+
+    # Check for 400 status code when unknown parameters are provided
+    response = await client.head(
+        "/xAPI/statements/?mamamia=herewegoagain",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+    assert response.status_code == 400
+    assert len(response.content) == 0
+
+    # Check for 400 status code when a negative limit parameter is provided
+    response = await client.head(
+        "/xAPI/statements/?limit=-1",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+    assert response.status_code == 400
+
+    # Check for 400 status code when both statementId and voidedStatementId are provided
+    response = await client.head(
+        f"/xAPI/statements/?statementId={id_1}&voidedStatementId={id_2}",
+        headers={"Authorization": f"Basic {basic_auth_credentials}"},
+    )
+    assert response.status_code == 400
+
+    # Check for 400 status code when invalid parameters are provided with a statementId
+    for invalid_param, value in [
+        ("activity", mock_activity()["id"]),
+        ("agent", json.dumps(mock_agent("mbox", 1))),
+        ("verb", "verb_1"),
+    ]:
+        response = await client.head(
+            f"/xAPI/statements/?{id_param}={id_1}&{invalid_param}={value}",
+            headers={"Authorization": f"Basic {basic_auth_credentials}"},
+        )
+        assert response.status_code == 400
+        assert len(response.content) == 0
+
+    backend_client_class_path = "ralph.api.routers.statements.BACKEND_CLIENT"
+    monkeypatch.setattr(backend_client_class_path, get_es_test_backend())
+
+    # Check for NO 400 status code when statementId is passed with authorized parameters
+    for valid_param, value in [("format", "ids"), ("attachments", "true")]:
+        response = await client.head(
+            f"/xAPI/statements/?{id_param}={id_1}&{valid_param}={value}",
+            headers={"Authorization": f"Basic {basic_auth_credentials}"},
+        )
+        assert response.status_code != 400

--- a/tests/api/test_statements_head.py
+++ b/tests/api/test_statements_head.py
@@ -93,7 +93,7 @@ async def test_api_statements_head_with_no_matching_statement(
         headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 404
     assert len(response.content) == 0
 
 

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -717,7 +717,9 @@ async def test_api_statements_post_list_with_forwarding(  # noqa: PLR0913
         )
         # Start forwarding LRS client
         async with AsyncClient(
-            app=app, base_url="http://testserver"
+            app=app,
+            base_url="http://testserver",
+            headers={"X-Experience-API-Version": "1.0.3"},
         ) as forwarding_client:
             # Send an xAPI statement to the forwarding client
             response = await forwarding_client.post(
@@ -741,7 +743,9 @@ async def test_api_statements_post_list_with_forwarding(  # noqa: PLR0913
             )
 
     # The statement should also be stored on the receiving client
-    async with AsyncClient() as receiving_client:
+    async with AsyncClient(
+        headers={"X-Experience-API-Version": "1.0.3"}
+    ) as receiving_client:
         response = await receiving_client.get(
             f"http://{RUNSERVER_TEST_HOST}:{RUNSERVER_TEST_PORT}/xAPI/statements/",
             headers={"Authorization": f"Basic {basic_auth_credentials}"},

--- a/tests/api/test_statements_post.py
+++ b/tests/api/test_statements_post.py
@@ -791,7 +791,7 @@ async def test_api_statements_post_scopes(  # noqa: PLR0913
         get_basic_auth_user.cache_clear()
 
     elif auth_method == "oidc":
-        sub = "123|oidc"
+        sub = "123_oidc"
         agent = {"openid": sub}
         oidc_token = mock_oidc_user(sub=sub, scopes=scopes)
         headers = {"Authorization": f"Bearer {oidc_token}"}

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -604,7 +604,9 @@ async def test_api_statements_put_with_forwarding(  # noqa: PLR0913
         )
         # Start forwarding LRS client
         async with AsyncClient(
-            app=app, base_url="http://testserver"
+            app=app,
+            base_url="http://testserver",
+            headers={"X-Experience-API-Version": "1.0.3"},
         ) as forwarding_client:
             # Send an xAPI statement to the forwarding client
             response = await forwarding_client.put(
@@ -628,7 +630,9 @@ async def test_api_statements_put_with_forwarding(  # noqa: PLR0913
             )
 
     # The statement should also be stored on the receiving client
-    async with AsyncClient() as receiving_client:
+    async with AsyncClient(
+        headers={"X-Experience-API-Version": "1.0.3"}
+    ) as receiving_client:
         response = await receiving_client.get(
             f"http://{RUNSERVER_TEST_HOST}:{RUNSERVER_TEST_PORT}/xAPI/statements/",
             headers={"Authorization": f"Basic {basic_auth_credentials}"},

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -343,7 +343,7 @@ async def test_api_statements_put_list_of_one(  # noqa: PLR0913
         json=[statement],
     )
 
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 @pytest.mark.anyio

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -38,6 +38,7 @@ from ..helpers import (
     assert_statement_get_responses_are_equivalent,
     mock_agent,
     mock_statement,
+    statements_are_equivalent,
     string_is_date,
 )
 
@@ -394,9 +395,7 @@ async def test_api_statements_put_duplicate_of_existing_statement(  # noqa: PLR0
         headers={"Authorization": f"Basic {basic_auth_credentials}"},
     )
     assert response.status_code == 200
-    assert_statement_get_responses_are_equivalent(
-        response.json(), {"statements": [statement]}
-    )
+    assert statements_are_equivalent(response.json(), statement)
 
 
 @pytest.mark.anyio

--- a/tests/api/test_statements_put.py
+++ b/tests/api/test_statements_put.py
@@ -678,7 +678,7 @@ async def test_api_statements_put_scopes(  # noqa: PLR0913
         get_basic_auth_user.cache_clear()
 
     elif auth_method == "oidc":
-        sub = "123|oidc"
+        sub = "123_oidc"
         agent = {"openid": sub}
         oidc_token = mock_oidc_user(sub=sub, scopes=scopes)
         headers = {"Authorization": f"Bearer {oidc_token}"}

--- a/tests/api/test_xapi_about.py
+++ b/tests/api/test_xapi_about.py
@@ -1,0 +1,15 @@
+"""Tests for the GET about endpoint of the Ralph API."""
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_xapi_about_get(client, basic_auth_credentials):
+    """Test the about API route (without X-Experience-API-Version request header)."""
+
+    response = await client.get(
+        "/xAPI/about", headers={"Authorization": f"Basic {basic_auth_credentials}"}
+    )
+
+    assert response.status_code == 200
+    assert "1.0.3" in response.json()["version"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 from ralph.models.edx.navigational.fields.events import NavigationalEventField
 from ralph.models.edx.navigational.statements import UISeqNext, UISeqPrev
-from ralph.models.xapi.base.common import IRI, LanguageTag, MailtoEmail
+from ralph.models.xapi.base.common import IRI, URI, LanguageTag, MailtoEmail
 from ralph.models.xapi.base.contexts import (
     BaseXapiContext,
 )
@@ -170,6 +170,13 @@ class IRIFactory(ModelFactory[IRI]):
     __set_as_default_factory_for_type__ = True
 
     root = lambda: IRI(mock_url())  # noqa: E731
+
+
+class URIFactory(ModelFactory[URI]):
+    __model__ = URI
+    __set_as_default_factory_for_type__ = True
+
+    root = lambda: URI(mock_url())  # noqa: E731
 
 
 class MailtoEmailFactory(ModelFactory[MailtoEmail]):

--- a/tests/fixtures/api.py
+++ b/tests/fixtures/api.py
@@ -11,5 +11,7 @@ from ralph.api import app
 async def client():
     """Return an AsyncClient for the FastAPI app."""
 
-    async with AsyncClient(app=app, base_url="http://test") as async_client:
+    async with AsyncClient(
+        app=app, base_url="http://test", headers={"X-Experience-API-Version": "1.0.3"}
+    ) as async_client:
         yield async_client

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -255,7 +255,7 @@ def _create_oidc_token(sub, scopes, target=None):
     )
 
 
-def mock_oidc_user(sub="123|oidc", scopes=None, target=None):
+def mock_oidc_user(sub="123_oidc", scopes=None, target=None):
     """Instantiate mock oidc user and return auth token."""
     # Default value for scope
     if scopes is None:
@@ -288,4 +288,4 @@ def mock_oidc_user(sub="123|oidc", scopes=None, target=None):
 @pytest.fixture
 def encoded_token():
     """Encode token with the private key (fixture)."""
-    return _create_oidc_token(sub="123|oidc", scopes=["all", "statements/read"])
+    return _create_oidc_token(sub="123_oidc", scopes=["all", "statements/read"])

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -915,7 +915,10 @@ def lrs():
                 server_ready = False
                 while not server_ready:
                     try:
-                        response = await client.get(f"http://{host}:{port}/whoami")
+                        response = await client.get(
+                            f"http://{host}:{port}/whoami",
+                            headers={"X-Experience-API-Version": "1.0.3"},
+                        )
                         assert response.status_code == 401
                         server_ready = True
                     except ConnectError:

--- a/tests/fixtures/statements.py
+++ b/tests/fixtures/statements.py
@@ -1,0 +1,115 @@
+"""Test fixtures for statements."""
+
+import pytest
+from elasticsearch.helpers import bulk
+
+from ralph.backends.data.base import BaseOperationType
+from ralph.backends.data.clickhouse import ClickHouseDataBackend
+from ralph.backends.data.mongo import MongoDataBackend
+
+from tests.fixtures.backends import (
+    CLICKHOUSE_TEST_DATABASE,
+    CLICKHOUSE_TEST_HOST,
+    CLICKHOUSE_TEST_PORT,
+    CLICKHOUSE_TEST_TABLE_NAME,
+    ES_TEST_INDEX,
+    MONGO_TEST_COLLECTION,
+    MONGO_TEST_DATABASE,
+    get_async_es_test_backend,
+    get_async_mongo_test_backend,
+    get_clickhouse_test_backend,
+    get_es_test_backend,
+    get_mongo_test_backend,
+)
+
+
+def insert_es_statements(es_client, statements, index=ES_TEST_INDEX):
+    """Insert a bunch of example statements into Elasticsearch for testing."""
+    bulk(
+        es_client,
+        [
+            {
+                "_index": index,
+                "_id": statement["id"],
+                "_op_type": "index",
+                "_source": statement,
+            }
+            for statement in statements
+        ],
+    )
+    es_client.indices.refresh()
+
+
+def insert_mongo_statements(mongo_client, statements, collection):
+    """Insert a bunch of example statements into MongoDB for testing."""
+    database = getattr(mongo_client, MONGO_TEST_DATABASE)
+    collection = getattr(database, collection)
+    collection.insert_many(
+        list(
+            MongoDataBackend.to_documents(
+                data=statements,
+                ignore_errors=True,
+                operation_type=BaseOperationType.CREATE,
+            )
+        )
+    )
+
+
+def insert_clickhouse_statements(statements, table):
+    """Insert a bunch of example statements into ClickHouse for testing."""
+    settings = ClickHouseDataBackend.settings_class(
+        HOST=CLICKHOUSE_TEST_HOST,
+        PORT=CLICKHOUSE_TEST_PORT,
+        DATABASE=CLICKHOUSE_TEST_DATABASE,
+        EVENT_TABLE_NAME=CLICKHOUSE_TEST_TABLE_NAME,
+    )
+    backend = ClickHouseDataBackend(settings=settings)
+    success = backend.write(statements, target=table)
+    assert success == len(statements)
+
+
+@pytest.fixture(params=["async_es", "async_mongo", "es", "mongo", "clickhouse"])
+def insert_statements_and_monkeypatch_backend(
+    request, es_custom, mongo_custom, clickhouse_custom, monkeypatch
+):
+    """(Security) Return a function that inserts statements into each backend."""
+
+    def _insert_statements_and_monkeypatch_backend(statements, target=None):
+        """Insert statements once into each backend."""
+        backend_client_class_path = "ralph.api.routers.statements.BACKEND_CLIENT"
+        if request.param == "async_es":
+            target = target if target else ES_TEST_INDEX
+            client = es_custom(index=target)
+            insert_es_statements(client, statements, target)
+            monkeypatch.setattr(backend_client_class_path, get_async_es_test_backend())
+            return
+        if request.param == "async_mongo":
+            target = target if target else MONGO_TEST_COLLECTION
+            client = mongo_custom(collection=target)
+            insert_mongo_statements(client, statements, target)
+            monkeypatch.setattr(
+                backend_client_class_path, get_async_mongo_test_backend()
+            )
+            return
+        if request.param == "es":
+            target = target if target else ES_TEST_INDEX
+            client = es_custom(index=target)
+            insert_es_statements(client, statements, target)
+            monkeypatch.setattr(backend_client_class_path, get_es_test_backend())
+            return
+        if request.param == "mongo":
+            target = target if target else MONGO_TEST_COLLECTION
+            client = mongo_custom(collection=target)
+            insert_mongo_statements(client, statements, target)
+            monkeypatch.setattr(backend_client_class_path, get_mongo_test_backend())
+            return
+        if request.param == "clickhouse":
+            target = target if target else CLICKHOUSE_TEST_TABLE_NAME
+            _ = clickhouse_custom(event_table_name=target)
+            insert_clickhouse_statements(statements, target)
+            monkeypatch.setattr(
+                backend_client_class_path, get_clickhouse_test_backend()
+            )
+            return
+
+    return _insert_statements_and_monkeypatch_backend


### PR DESCRIPTION
## Purpose

Improve xapi specification conformance tested via lrs-conformance-test-suite

## Proposal
 
- [x] Send appropriate error response and status code when validation or type error
- [x] Check "X-Experience-API-Version" header in every request except for "/xAPI/about"
- [x] Include the "X-Experience-API-Version" header in every response
- [x] Create "/xAPI/about" endpoint that returns JSON response containing information about this LRS
- [x] Make LRS respond to any HTTP HEAD request as it would have responded to an otherwise identical HTTP GET request except the message-body MUST be omitted
- [x] Handle openid property as a URI rather than a string 
- [x] Add X-Experience-API-Consistent-Through header 
- [x] Make member property of Identified Group optional 