### PR TITLE
Feature/update typing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -718,7 +718,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.12]
           filters:
             tags:
               only: /.*/
@@ -731,7 +731,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-image: [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+              python-image: [python:3.12]
           requires:
             - build
           filters:
@@ -741,7 +741,7 @@ workflows:
           matrix:
             parameters:
               python-image:
-                [python:3.8, python:3.9, python:3.10, python:3.11, python:3.12]
+                [python:3.12]
           filters:
             tags:
               only: /.*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = { file = "LICENSE.md" }
 keywords = ["LRS", "Analytics", "xAPI", "Open edX"]
 dependencies = [

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,10 +1,10 @@
 """Main module for Ralph's LRS API."""
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
-from typing import Any, Dict, List, Union
+from typing import Annotated, Any
 from urllib.parse import urlparse
 
 import sentry_sdk
@@ -23,12 +23,12 @@ from .routers import health, statements, xapi
 
 
 @lru_cache(maxsize=None)
-def get_health_check_routes() -> List:
+def get_health_check_routes() -> list:
     """Return the health check routes."""
     return [route.path for route in health.router.routes]
 
 
-def filter_transactions(event: Dict, hint) -> Union[Dict, None]:  # noqa: ARG001
+def filter_transactions(event: Mapping, hint) -> dict | None:  # noqa: ARG001
     """Filter transactions for Sentry."""
     url = urlparse(event["request"]["url"])
 
@@ -56,8 +56,8 @@ app.include_router(xapi.router)
 
 @app.get("/whoami")
 async def whoami(
-    user: AuthenticatedUser = Depends(get_authenticated_user),
-) -> Dict[str, Any]:
+    user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
+) -> dict[str, Any]:
     """Return the current user's username along with their scopes."""
     return {
         "agent": user.agent.model_dump(mode="json", exclude_none=True),

--- a/src/ralph/api/auth/__init__.py
+++ b/src/ralph/api/auth/__init__.py
@@ -1,6 +1,6 @@
 """Main module for Ralph's LRS API authentication."""
 
-from typing import Optional
+from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import SecurityScopes
@@ -12,10 +12,10 @@ from ralph.conf import settings
 
 
 def get_authenticated_user(
-    security_scopes: SecurityScopes = SecurityScopes([]),
-    basic_auth_user: Optional[AuthenticatedUser] = Depends(get_basic_auth_user),
-    oidc_auth_user: Optional[AuthenticatedUser] = Depends(get_oidc_user),
-    cozy_auth_user: Optional[AuthenticatedUser] = Depends(get_cozy_user),
+    security_scopes: SecurityScopes,
+    basic_auth_user: Annotated[AuthenticatedUser, Depends(get_basic_auth_user)],
+    oidc_auth_user: Annotated[AuthenticatedUser, Depends(get_oidc_user)],
+    cozy_auth_user: Annotated[AuthenticatedUser, Depends(get_cozy_user)],
 ) -> AuthenticatedUser:
     """Authenticate user with any allowed method, using credentials in the header."""
     if basic_auth_user:

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Sequence
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 import bcrypt
 from cachetools import TTLCache, cached
@@ -113,7 +113,7 @@ def get_stored_credentials(auth_file: os.PathLike) -> ServerUsersCredentials:
     ),
 )
 def get_basic_auth_user(
-    credentials: Annotated[Optional[HTTPBasicCredentials], Depends(security)],
+    credentials: Annotated[HTTPBasicCredentials | None, Depends(security)],
 ) -> AuthenticatedUser | None:
     """Check valid auth parameters.
 

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Sequence
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
-from typing import Annotated, Any, Iterator, List, Optional
+from typing import Annotated, Any, Optional
 
 import bcrypt
 from cachetools import TTLCache, cached

--- a/src/ralph/api/auth/basic.py
+++ b/src/ralph/api/auth/basic.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from collections.abc import Iterator, Sequence
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
@@ -41,7 +42,7 @@ class UserCredentials(AuthenticatedUser):
     username: str
 
 
-class ServerUsersCredentials(RootModel[List[UserCredentials]]):
+class ServerUsersCredentials(RootModel[Sequence[UserCredentials]]):
     """Custom root pydantic model.
 
     Describe expected list of all server users credentials as stored in

--- a/src/ralph/api/auth/cozy.py
+++ b/src/ralph/api/auth/cozy.py
@@ -2,14 +2,14 @@
 
 import logging
 import re
-from typing import Dict, List, Optional
+from collections.abc import Mapping
+from typing import Annotated
 
 import httpx
 from fastapi import Header, HTTPException, status
 from jose import ExpiredSignatureError, JWTError, jwt
 from jose.exceptions import JWTClaimsError
 from pydantic import ValidationError
-from typing_extensions import Annotated
 
 from ralph.api.auth.token import BaseIDToken
 from ralph.api.auth.user import AuthenticatedUser
@@ -42,12 +42,12 @@ class CozyIDToken(BaseIDToken):
         session_id (str): CozyStack session identifier.
     """
 
-    sub: Optional[str] = None
-    aud: List[str]
-    session_id: Optional[str] = None
+    sub: str | None = None
+    aud: list[str]
+    session_id: str | None = None
 
 
-def decode_auth_token(x_auth_token: str) -> Dict:
+def decode_auth_token(x_auth_token: str) -> dict:
     """Decode Cozy ID token (jwt).
 
     Attributes:
@@ -83,7 +83,7 @@ def decode_auth_token(x_auth_token: str) -> Dict:
         raise unauthorized_http_exception from exc
 
 
-def model_validate_cozy_id_token(decoded_token: Dict) -> CozyIDToken:
+def model_validate_cozy_id_token(decoded_token: Mapping) -> CozyIDToken:
     """Validate decoded authentication token data.
 
     Attributes:

--- a/src/ralph/api/auth/cozy.py
+++ b/src/ralph/api/auth/cozy.py
@@ -87,7 +87,7 @@ def model_validate_cozy_id_token(decoded_token: Mapping) -> CozyIDToken:
     """Validate decoded authentication token data.
 
     Attributes:
-        decoded_token (Dict): Cozy decoded token.
+        decoded_token (dict): Cozy decoded token.
 
     Return:
         CozyIDToken: Decoded authentication token data.

--- a/src/ralph/api/auth/oidc.py
+++ b/src/ralph/api/auth/oidc.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import lru_cache
-from typing import Dict, Optional
+from typing import Annotated
 
 import requests
 from fastapi import Depends, HTTPException, status
@@ -10,7 +10,6 @@ from fastapi.security import HTTPBearer, OpenIdConnect
 from jose import ExpiredSignatureError, JWTError, jwt
 from jose.exceptions import JWTClaimsError
 from pydantic import AnyUrl
-from typing_extensions import Annotated
 
 from ralph.api.auth.token import BaseIDToken
 from ralph.api.auth.user import AuthenticatedUser, UserScopes
@@ -45,12 +44,12 @@ class IDToken(BaseIDToken):
     """
 
     sub: str
-    aud: Optional[str] = None
+    aud: str | None = None
     exp: int
 
 
 @lru_cache()
-def discover_provider(base_url: AnyUrl) -> Dict:
+def discover_provider(base_url: AnyUrl) -> dict:
     """Discover the authentication server (or OpenId Provider) configuration."""
     try:
         response = requests.get(f"{base_url}{OPENID_CONFIGURATION_PATH}", timeout=5)
@@ -68,7 +67,7 @@ def discover_provider(base_url: AnyUrl) -> Dict:
 
 
 @lru_cache()
-def get_public_keys(jwks_uri: AnyUrl) -> Dict:
+def get_public_keys(jwks_uri: AnyUrl) -> dict:
     """Retrieve the public keys used by the provider server for signing."""
     try:
         response = requests.get(jwks_uri, timeout=5)
@@ -90,7 +89,7 @@ def get_public_keys(jwks_uri: AnyUrl) -> Dict:
 
 
 def get_oidc_user(
-    auth_header: Annotated[Optional[HTTPBearer], Depends(oauth2_scheme)],
+    auth_header: Annotated[HTTPBearer | None, Depends(oauth2_scheme)],
 ) -> AuthenticatedUser | None:
     """Decode and validate OpenId Connect ID token against issuer in config.
 

--- a/src/ralph/api/auth/token.py
+++ b/src/ralph/api/auth/token.py
@@ -1,7 +1,5 @@
 """Base IDToken class for the Ralph API."""
 
-from typing import Optional
-
 from pydantic import BaseModel, ConfigDict
 
 
@@ -20,7 +18,7 @@ class BaseIDToken(BaseModel):
 
     iss: str
     iat: int
-    scope: Optional[str] = None
-    target: Optional[str] = None
+    scope: str | None = None
+    target: str | None = None
 
     model_config = ConfigDict(extra="ignore")

--- a/src/ralph/api/auth/user.py
+++ b/src/ralph/api/auth/user.py
@@ -1,6 +1,6 @@
 """Authenticated user for the Ralph API."""
 
-from typing import FrozenSet, Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, RootModel
 
@@ -20,7 +20,7 @@ Scope = Literal[
 ]
 
 
-class UserScopes(RootModel[FrozenSet[Scope]]):
+class UserScopes(RootModel[frozenset[Scope]]):
     """Scopes available to users."""
 
     def is_authorized(self, requested_scope: Scope):
@@ -66,4 +66,4 @@ class AuthenticatedUser(BaseModel):
 
     agent: BaseXapiAgent
     scopes: UserScopes
-    target: Optional[str] = None
+    target: str | None = None

--- a/src/ralph/api/forwarding.py
+++ b/src/ralph/api/forwarding.py
@@ -1,8 +1,9 @@
 """xAPI statement forwarding background task."""
 
 import logging
+from collections.abc import Mapping, Sequence
 from functools import lru_cache
-from typing import List, Literal, Union
+from typing import Literal
 
 from httpx import AsyncClient, AsyncHTTPTransport, HTTPStatusError, RequestError
 from starlette.datastructures import Headers
@@ -13,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 @lru_cache
-def get_active_xapi_forwardings() -> List[XapiForwardingConfigurationSettings]:
+def get_active_xapi_forwardings() -> list[XapiForwardingConfigurationSettings]:
     """Return a list of active xAPI forwarding configuration settings."""
-    active_forwardings: List = []
+    active_forwardings: list = []
     if not settings.XAPI_FORWARDINGS:
         logger.info("No xAPI forwarding configured; forwarding is disabled.")
         return active_forwardings
@@ -34,9 +35,9 @@ def get_active_xapi_forwardings() -> List[XapiForwardingConfigurationSettings]:
 
 
 async def forward_xapi_statements(
-    statements: Union[dict, List[dict]],
+    statements: Mapping | Sequence[Mapping],
     method: Literal["post", "put"],
-    headers: Union[dict, Headers],
+    headers: Mapping | Headers,
 ) -> None:
     """Forward xAPI statements."""
     for forwarding in get_active_xapi_forwardings():

--- a/src/ralph/api/models.py
+++ b/src/ralph/api/models.py
@@ -4,7 +4,6 @@ Allows to be exactly as lax as we want when it comes to exact object shape and
 validation.
 """
 
-from typing import Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -58,7 +57,7 @@ class LaxStatement(BaseModelWithLaxConfig):
     qualify an object as an XAPI statement.
     """
 
-    actor: Union[BaseXapiAgent, BaseXapiGroup]
-    id: Optional[UUID] = None
+    actor: BaseXapiAgent | BaseXapiGroup
+    id: UUID | None = None
     object: LaxObjectField
     verb: LaxVerbField

--- a/src/ralph/api/routers/health.py
+++ b/src/ralph/api/routers/health.py
@@ -1,7 +1,6 @@
 """API routes related to application health checking."""
 
 import logging
-from typing import Union
 
 from fastapi import APIRouter, Response, status
 from pydantic import BaseModel
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-BACKEND_CLIENT: Union[BaseLRSBackend, BaseAsyncLRSBackend] = get_backend_class(
+BACKEND_CLIENT: BaseLRSBackend | BaseAsyncLRSBackend = get_backend_class(
     backends=get_lrs_backends(), name=settings.RUNSERVER_BACKEND
 )()
 

--- a/src/ralph/backends/cozystack/client.py
+++ b/src/ralph/backends/cozystack/client.py
@@ -1,7 +1,8 @@
 """CozyStack client for Ralph."""
 
 import os
-from typing import Any, Dict, Iterable, List
+from typing import Any
+from collections.abc import Iterable, Mapping, Sequence
 
 import httpx
 from fastapi import HTTPException, status
@@ -92,7 +93,7 @@ class CozyStackClient:
 
             raise exceptions.CozyStackError() from exc
 
-    def create_index(self, target: str, fields: List[str]) -> Dict:
+    def create_index(self, target: str, fields: Sequence[str]) -> dict:
         """Create an index for some documents.
 
         Attributes:
@@ -115,7 +116,7 @@ class CozyStackClient:
             self.check_error(response)
             return response.json()
 
-    def delete_database(self, target: str) -> Dict:
+    def delete_database(self, target: str) -> dict:
         """Delete doctype database.
 
         Attributes:
@@ -135,14 +136,14 @@ class CozyStackClient:
             self.check_error(response)
             return response.json()
 
-    def list_all_doctypes(self, target: str) -> List[str]:
+    def list_all_doctypes(self, target: str) -> list[str]:
         """List all doctypes available on targeted instance.
 
         Attributes:
             target (str): The target instance url with auth data.
 
         Return:
-            List[str]: The doctypes available on targeted instance.
+            Sequence[str]: The doctypes available on targeted instance.
 
         Raises:
             fastapi.HTTPException: When target is malformed.
@@ -153,7 +154,7 @@ class CozyStackClient:
             self.check_error(response)
             return response.json()
 
-    def find(self, target: str, query: Dict) -> Dict:
+    def find(self, target: str, query: Mapping) -> dict:
         """Find document using a mango selector.
 
         Attributes:
@@ -178,7 +179,7 @@ class CozyStackClient:
             return response.json()
 
     @classmethod
-    def _check_item_for_update_or_delete_operation(cls, item: Dict):
+    def _check_item_for_update_or_delete_operation(cls, item: Mapping):
         """Raise ValueError if _id or _rev field missing in item."""
         for field in ["_id", "_rev"]:
             if field not in item:
@@ -187,7 +188,7 @@ class CozyStackClient:
                 )
 
     @classmethod
-    def _prepare_data(cls, data: Iterable[dict], operation_type: BaseOperationType):
+    def _prepare_data(cls, data: Iterable[Mapping], operation_type: BaseOperationType):
         """Enrich data based on operation type."""
         prepared_data = []
 
@@ -217,7 +218,7 @@ class CozyStackClient:
         return prepared_data
 
     def bulk_operation(
-        self, target: str, data: Iterable[Dict], operation_type: BaseOperationType
+        self, target: str, data: Iterable[Mapping], operation_type: BaseOperationType
     ) -> int:
         """Create, update, or delete multiple documents at the same time within a single request.
 

--- a/src/ralph/backends/cozystack/client.py
+++ b/src/ralph/backends/cozystack/client.py
@@ -1,8 +1,8 @@
 """CozyStack client for Ralph."""
 
 import os
-from typing import Any
 from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
 import httpx
 from fastapi import HTTPException, status

--- a/src/ralph/backends/data/async_es.py
+++ b/src/ralph/backends/data/async_es.py
@@ -1,8 +1,9 @@
 """Asynchronous Elasticsearch data backend for Ralph."""
 
 import logging
+from collections.abc import AsyncIterator, Iterable, Mapping
 from io import IOBase
-from typing import AsyncIterator, Iterable, Optional, TypeVar, Union
+from typing import TypeVar
 
 from elasticsearch import ApiError, AsyncElasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, async_streaming_bulk
@@ -30,7 +31,7 @@ class AsyncESDataBackend(
     name = "async_es"
     unsupported_operation_types = {BaseOperationType.APPEND}
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, settings: Settings | None = None):
         """Instantiate the asynchronous Elasticsearch client.
 
         Args:
@@ -70,8 +71,8 @@ class AsyncESDataBackend(
         return DataBackendStatus.ERROR
 
     async def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[AsyncIterator[str], AsyncIterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> AsyncIterator[str] | AsyncIterator[dict]:
         """List available Elasticsearch indices, data streams and aliases.
 
         Args:
@@ -111,14 +112,14 @@ class AsyncESDataBackend(
 
     async def read(  # noqa: PLR0913
         self,
-        query: Optional[ESQuery] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: ESQuery | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        prefetch: Optional[PositiveInt] = None,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
+        prefetch: PositiveInt | None = None,
+        max_statements: PositiveInt | None = None,
+    ) -> AsyncIterator[bytes] | AsyncIterator[dict]:
         """Read documents matching the query in the target index and yield them.
 
         Args:
@@ -158,7 +159,7 @@ class AsyncESDataBackend(
     async def _read_dicts(
         self,
         query: ESQuery,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> AsyncIterator[dict]:
@@ -204,12 +205,12 @@ class AsyncESDataBackend(
 
     async def write(  # noqa: PLR0913
         self,
-        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        data: IOBase | Iterable[bytes] | Iterable[dict],
+        target: str | None = None,
+        chunk_size: int | None = None,
         ignore_errors: bool = False,
-        operation_type: Optional[BaseOperationType] = None,
-        concurrency: Optional[PositiveInt] = None,
+        operation_type: BaseOperationType | None = None,
+        concurrency: PositiveInt | None = None,
     ) -> int:
         """Write data documents to the target index and return their count.
 
@@ -243,8 +244,8 @@ class AsyncESDataBackend(
 
     async def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
         operation_type: BaseOperationType,

--- a/src/ralph/backends/data/async_ws.py
+++ b/src/ralph/backends/data/async_ws.py
@@ -1,7 +1,7 @@
 """Websocket stream backend for Ralph."""
 
 import logging
-from typing import AsyncIterator, Optional, Union
+from collections.abc import AsyncIterator
 
 import websockets
 from pydantic import AnyUrl, PositiveInt
@@ -47,15 +47,15 @@ class WSClientOptions(ClientOptions):
         write_limit (int): High-water mark of write buffer in bytes.
     """
 
-    close_timeout: Optional[float] = None
-    compression: Optional[str] = "deflate"
-    max_size: Optional[int] = 2**20
-    max_queue: Optional[int] = 2**5
-    open_timeout: Optional[float] = 10
-    origin: Optional[str] = None
-    ping_interval: Optional[float] = 20
-    ping_timeout: Optional[float] = 20
-    user_agent_header: Optional[str] = USER_AGENT
+    close_timeout: float | None = None
+    compression: str | None = "deflate"
+    max_size: int | None = 2**20
+    max_queue: int | None = 2**5
+    open_timeout: float | None = 10
+    origin: str | None = None
+    ping_interval: float | None = 20
+    ping_timeout: float | None = 20
+    user_agent_header: str | None = USER_AGENT
     write_limit: int = 2**16
 
 
@@ -82,7 +82,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, str]):
 
     name = "async_ws"
 
-    def __init__(self, settings: Optional[WSDataBackendSettings] = None):
+    def __init__(self, settings: WSDataBackendSettings | None = None):
         """Instantiate the async websocket data backend.
 
         Args:
@@ -124,14 +124,14 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, str]):
 
     async def read(  # noqa: PLR0913
         self,
-        query: Optional[str] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: str | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        prefetch: Optional[PositiveInt] = None,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[AsyncIterator[bytes], AsyncIterator[dict]]:
+        prefetch: PositiveInt | None = None,
+        max_statements: PositiveInt | None = None,
+    ) -> AsyncIterator[bytes] | AsyncIterator[dict]:
         """Read records matching the `query` in the `target` container and yield them.
 
         Args:
@@ -174,7 +174,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, str]):
     async def _read_bytes(
         self,
         query: str,  # noqa: ARG002
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> AsyncIterator[bytes]:
@@ -198,7 +198,7 @@ class AsyncWSDataBackend(BaseAsyncDataBackend[WSDataBackendSettings, str]):
     async def _read_dicts(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
     ) -> AsyncIterator[dict]:

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -8,11 +8,21 @@ from enum import Enum, IntEnum, unique
 from inspect import isclass
 from io import IOBase
 from itertools import chain
-from typing import Any, Generic, Type, TypeVar, Union, get_args, get_origin
+from typing import (
+    Any,
+    Generic,
+    Self,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
+
+from types import get_original_bases
 
 from pydantic import BaseModel, PositiveInt, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing_extensions import Self, get_original_bases
 
 from ralph.conf import BASE_SETTINGS_CONFIG, core_settings
 from ralph.exceptions import BackendParameterException

--- a/src/ralph/backends/data/base.py
+++ b/src/ralph/backends/data/base.py
@@ -8,6 +8,7 @@ from enum import Enum, IntEnum, unique
 from inspect import isclass
 from io import IOBase
 from itertools import chain
+from types import get_original_bases
 from typing import (
     Any,
     Generic,
@@ -18,8 +19,6 @@ from typing import (
     get_args,
     get_origin,
 )
-
-from types import get_original_bases
 
 from pydantic import BaseModel, PositiveInt, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/src/ralph/backends/data/cozystack.py
+++ b/src/ralph/backends/data/cozystack.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, Iterator, List, Optional, TypeVar, Union
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from typing import Annotated, TypeVar
 
 from fastapi import HTTPException, status
 from pydantic import NonNegativeInt, StringConstraints
 from pydantic_settings import SettingsConfigDict
-from typing_extensions import Annotated
 
 from ralph.backends.cozystack import CozyStackClient, CozyStackError
 from ralph.backends.data.base import (
@@ -64,16 +64,16 @@ class CozyStackQuery(BaseQuery):
 
     """
 
-    selector: dict = {}
+    selector: Mapping = {}
 
-    limit: Optional[NonNegativeInt] = None
-    skip: Optional[NonNegativeInt] = None
+    limit: NonNegativeInt | None = None
+    skip: NonNegativeInt | None = None
 
-    sort: Optional[List[dict]] = None
-    fields: Optional[List[str]] = None
+    sort: Sequence[Mapping] | None = None
+    fields: Sequence[str] | None = None
 
-    next: Optional[bool] = None
-    bookmark: Optional[str] = None
+    next: bool | None = None
+    bookmark: str | None = None
 
 
 Settings = TypeVar("Settings", bound=CozyStackDataBackendSettings)
@@ -87,7 +87,7 @@ class CozyStackDataBackend(
     name = "cozy-stack"
     unsupported_operation_types = {BaseOperationType.APPEND}
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, settings: Settings | None = None):
         """Instantiate the CozyStack data backend.
 
         Args:
@@ -106,8 +106,8 @@ class CozyStackDataBackend(
         return DataBackendStatus.OK
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List doctypes in the `target` database.
 
         Args:
@@ -138,7 +138,7 @@ class CozyStackDataBackend(
     def _read_dicts(
         self,
         query: CozyStackQuery,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,  # noqa: ARG002
         ignore_errors: bool,
     ) -> Iterator[dict]:
@@ -168,8 +168,8 @@ class CozyStackDataBackend(
 
     def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,  # noqa: ARG002
         ignore_errors: bool,  # noqa: ARG002
         operation_type: BaseOperationType,

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -4,13 +4,12 @@ import logging
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from io import IOBase
 from pathlib import Path
-from typing import Literal, TypeVar
+from typing import Literal, Self, TypeVar
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
 from pydantic import BaseModel, PositiveInt, ValidationError
 from pydantic_settings import SettingsConfigDict
-from typing_extensions import Self
 
 from ralph.backends.data.base import (
     BaseDataBackend,

--- a/src/ralph/backends/data/es.py
+++ b/src/ralph/backends/data/es.py
@@ -1,9 +1,10 @@
 """Elasticsearch data backend for Ralph."""
 
 import logging
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from io import IOBase
 from pathlib import Path
-from typing import Iterable, Iterator, List, Literal, Optional, TypeVar, Union
+from typing import Literal, TypeVar
 
 from elasticsearch import ApiError, Elasticsearch, TransportError
 from elasticsearch.helpers import BulkIndexError, streaming_bulk
@@ -29,8 +30,8 @@ logger = logging.getLogger(__name__)
 class ESClientOptions(ClientOptions):
     """Elasticsearch additional client options."""
 
-    ca_certs: Optional[Path] = None
-    verify_certs: Optional[bool] = None
+    ca_certs: Path | None = None
+    verify_certs: bool | None = None
 
 
 class ESDataBackendSettings(BaseDataBackendSettings):
@@ -65,7 +66,7 @@ class ESDataBackendSettings(BaseDataBackendSettings):
         "http://localhost:9200"  # CommaSeparatedTuple("http://localhost:9200")
     )
     POINT_IN_TIME_KEEP_ALIVE: str = "1m"
-    REFRESH_AFTER_WRITE: Optional[Union[Literal["false", "true", "wait_for"]]] = None
+    REFRESH_AFTER_WRITE: Literal["false", "true", "wait_for"] | None = None
 
 
 class ESQueryPit(BaseModel):
@@ -77,8 +78,8 @@ class ESQueryPit(BaseModel):
             time alive.
     """
 
-    id: Union[str, None] = None
-    keep_alive: Union[str, None] = None
+    id: str | None = None
+    keep_alive: str | None = None
 
 
 class ESQuery(BaseQuery):
@@ -102,12 +103,12 @@ class ESQuery(BaseQuery):
             Not used. Always set to `False`.
     """
 
-    q: Optional[str] = None
-    query: dict = {"match_all": {}}
+    q: str | None = None
+    query: Mapping = {"match_all": {}}
     pit: ESQueryPit = ESQueryPit()
-    size: Optional[int] = None
-    sort: Union[str, List[dict]] = "_shard_doc"
-    search_after: Optional[list] = None
+    size: int | None = None
+    sort: str | Sequence[dict] = "_shard_doc"
+    search_after: Sequence | None = None
     track_total_hits: Literal[False] = False
 
     @classmethod
@@ -130,7 +131,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
     name = "es"
     unsupported_operation_types = {BaseOperationType.APPEND}
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, settings: Settings | None = None):
         """Instantiate the Elasticsearch data backend.
 
         Args:
@@ -170,8 +171,8 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
         return DataBackendStatus.ERROR
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List available Elasticsearch indices, data streams and aliases.
 
         Args:
@@ -211,13 +212,13 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[ESQuery] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: ESQuery | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[Iterator[bytes], Iterator[dict]]:
+        max_statements: PositiveInt | None = None,
+    ) -> Iterator[bytes] | Iterator[dict]:
         """Read documents matching the query in the target index and yield them.
 
         Args:
@@ -246,7 +247,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
     def _read_dicts(
         self,
         query: ESQuery,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> Iterator[dict]:
@@ -289,11 +290,11 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
 
     def write(
         self,
-        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        data: IOBase | Iterable[bytes] | Iterable[dict],
+        target: str | None = None,
+        chunk_size: int | None = None,
         ignore_errors: bool = False,
-        operation_type: Optional[BaseOperationType] = None,
+        operation_type: BaseOperationType | None = None,
     ) -> int:
         """Write data documents to the target index and return their count.
 
@@ -323,8 +324,8 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
 
     def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
         operation_type: BaseOperationType,
@@ -372,7 +373,7 @@ class ESDataBackend(BaseDataBackend[Settings, ESQuery], Writable, Listable):
 
     @staticmethod
     def to_documents(
-        data: Iterable[dict],
+        data: Iterable[Mapping],
         target: str,
         operation_type: BaseOperationType,
     ) -> Iterator[dict]:

--- a/src/ralph/backends/data/fs.py
+++ b/src/ralph/backends/data/fs.py
@@ -2,10 +2,11 @@
 
 import logging
 import os
+from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timezone
 from io import BufferedReader, IOBase
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, Tuple, TypeVar, Union
+from typing import TypeVar
 from uuid import uuid4
 
 from pydantic import PositiveInt, model_validator
@@ -77,7 +78,7 @@ class FSDataBackend(
     default_operation_type = BaseOperationType.CREATE
     unsupported_operation_types = {BaseOperationType.DELETE}
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, settings: Settings | None = None):
         """Create the default target directory if it does not exist.
 
         Args:
@@ -110,8 +111,8 @@ class FSDataBackend(
         return DataBackendStatus.OK
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List files and directories in the target directory.
 
         Args:
@@ -162,13 +163,13 @@ class FSDataBackend(
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[str] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: str | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[Iterator[bytes], Iterator[dict]]:
+        max_statements: PositiveInt | None = None,
+    ) -> Iterator[bytes] | Iterator[dict]:
         """Read files matching the query in the target folder and yield them.
 
         Args:
@@ -202,7 +203,7 @@ class FSDataBackend(
     def _read_bytes(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> Iterator[bytes]:
@@ -216,7 +217,7 @@ class FSDataBackend(
     def _read_dicts(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,  # noqa: ARG002
         ignore_errors: bool,
     ) -> Iterator[dict]:
@@ -243,8 +244,8 @@ class FSDataBackend(
         )
 
     def _iter_files_matching_query(
-        self, target: Optional[str], query: str
-    ) -> Iterator[Tuple[BufferedReader, Path]]:
+        self, target: str | None, query: str
+    ) -> Iterator[tuple[BufferedReader, Path]]:
         """Return file/path tuples for files matching the query in the target folder."""
         if not query:
             query = self.default_query_string
@@ -266,11 +267,11 @@ class FSDataBackend(
 
     def write(
         self,
-        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        data: IOBase | Iterable[bytes] | Iterable[dict],
+        target: str | None = None,
+        chunk_size: int | None = None,
         ignore_errors: bool = False,
-        operation_type: Optional[BaseOperationType] = None,
+        operation_type: BaseOperationType | None = None,
     ) -> int:
         """Write data records to the target file and return their count.
 
@@ -307,8 +308,8 @@ class FSDataBackend(
 
     def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
         operation_type: BaseOperationType,
@@ -321,7 +322,7 @@ class FSDataBackend(
     def _write_bytes(
         self,
         data: Iterable[bytes],
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,  # noqa: ARG002
         ignore_errors: bool,  # noqa: ARG002
         operation_type: BaseOperationType,

--- a/src/ralph/backends/data/ldp.py
+++ b/src/ralph/backends/data/ldp.py
@@ -1,7 +1,8 @@
 """OVH's LDP data backend for Ralph."""
 
 import logging
-from typing import Iterator, Literal, Optional, Union
+from collections.abc import Iterator
+from typing import Literal
 
 import ovh
 import requests
@@ -41,10 +42,10 @@ class LDPDataBackendSettings(BaseDataBackendSettings):
         **SettingsConfigDict(env_prefix="RALPH_BACKENDS__DATA__LDP__"),
     }
 
-    APPLICATION_KEY: Optional[str] = None
-    APPLICATION_SECRET: Optional[str] = None
-    CONSUMER_KEY: Optional[str] = None
-    DEFAULT_STREAM_ID: Optional[str] = None
+    APPLICATION_KEY: str | None = None
+    APPLICATION_SECRET: str | None = None
+    CONSUMER_KEY: str | None = None
+    DEFAULT_STREAM_ID: str | None = None
     ENDPOINT: Literal[
         "ovh-eu",
         "ovh-us",
@@ -54,8 +55,8 @@ class LDPDataBackendSettings(BaseDataBackendSettings):
         "soyoustart-eu",
         "soyoustart-ca",
     ] = "ovh-eu"
-    REQUEST_TIMEOUT: Optional[int] = None
-    SERVICE_NAME: Optional[str] = None
+    REQUEST_TIMEOUT: int | None = None
+    SERVICE_NAME: str | None = None
     READ_CHUNK_SIZE: int = 4096
 
 
@@ -68,7 +69,7 @@ class LDPDataBackend(
 
     name = "ldp"
 
-    def __init__(self, settings: Optional[LDPDataBackendSettings] = None):
+    def __init__(self, settings: LDPDataBackendSettings | None = None):
         """Instantiate the OVH LDP client.
 
         Args:
@@ -106,8 +107,8 @@ class LDPDataBackend(
         return DataBackendStatus.OK
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List archives for a given target stream_id.
 
         Args:
@@ -155,13 +156,13 @@ class LDPDataBackend(
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[str] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: str | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = True,
         ignore_errors: bool = False,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[Iterator[bytes], Iterator[dict]]:
+        max_statements: PositiveInt | None = None,
+    ) -> Iterator[bytes] | Iterator[dict]:
         """Read an archive matching the query in the target stream_id and yield it.
 
         Args:
@@ -189,7 +190,7 @@ class LDPDataBackend(
     def _read_dicts(
         self,
         query: str,  # noqa: ARG002
-        target: Optional[str],  # noqa: ARG002
+        target: str | None,  # noqa: ARG002
         chunk_size: int,  # noqa: ARG002
         ignore_errors: bool,  # noqa: ARG002
     ) -> Iterator[dict]:
@@ -204,7 +205,7 @@ class LDPDataBackend(
     def _read_bytes(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
     ) -> Iterator[bytes]:
@@ -257,7 +258,7 @@ class LDPDataBackend(
         self._client = None
         logger.info("No open connections to close; skipping")
 
-    def _get_archive_endpoint(self, stream_id: Optional[str] = None) -> str:
+    def _get_archive_endpoint(self, stream_id: str | None = None) -> str:
         """Return OVH's archive endpoint."""
         stream_id = stream_id if stream_id else self.stream_id
         if None in (self.service_name, stream_id):
@@ -282,7 +283,7 @@ class LDPDataBackend(
         logger.debug("Temporary URL: %s", download_url)
         return download_url
 
-    def _details(self, stream_id: str, name: str) -> Optional[dict]:
+    def _details(self, stream_id: str, name: str) -> dict | None:
         """Return `name` archive details.
 
         Expected JSON response looks like:

--- a/src/ralph/backends/data/s3.py
+++ b/src/ralph/backends/data/s3.py
@@ -1,8 +1,8 @@
 """S3 data backend for Ralph."""
 
 import logging
+from collections.abc import Iterable, Iterator, Mapping
 from io import IOBase
-from typing import Iterable, Iterator, Optional, Union
 from uuid import uuid4
 
 import boto3
@@ -55,12 +55,12 @@ class S3DataBackendSettings(BaseDataBackendSettings):
         **SettingsConfigDict(env_prefix="RALPH_BACKENDS__DATA__S3__"),
     }
 
-    ACCESS_KEY_ID: Optional[str] = None
-    SECRET_ACCESS_KEY: Optional[str] = None
-    SESSION_TOKEN: Optional[str] = None
-    ENDPOINT_URL: Optional[str] = None
-    DEFAULT_REGION: Optional[str] = None
-    DEFAULT_BUCKET_NAME: Optional[str] = None
+    ACCESS_KEY_ID: str | None = None
+    SECRET_ACCESS_KEY: str | None = None
+    SESSION_TOKEN: str | None = None
+    ENDPOINT_URL: str | None = None
+    DEFAULT_REGION: str | None = None
+    DEFAULT_BUCKET_NAME: str | None = None
     READ_CHUNK_SIZE: int = 4096
     WRITE_CHUNK_SIZE: int = 4096
 
@@ -78,7 +78,7 @@ class S3DataBackend(
         BaseOperationType.UPDATE,
     }
 
-    def __init__(self, settings: Optional[S3DataBackendSettings] = None):
+    def __init__(self, settings: S3DataBackendSettings | None = None):
         """Instantiate the AWS S3 client."""
         super().__init__(settings)
         self.default_bucket_name = self.settings.DEFAULT_BUCKET_NAME
@@ -112,8 +112,8 @@ class S3DataBackend(
         return DataBackendStatus.OK
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List objects for the target bucket.
 
         Args:
@@ -158,13 +158,13 @@ class S3DataBackend(
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[str] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: str | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[Iterator[bytes], Iterator[dict]]:
+        max_statements: PositiveInt | None = None,
+    ) -> Iterator[bytes] | Iterator[dict]:
         """Read an object matching the `query` in the `target` bucket and yield it.
 
         Args:
@@ -197,7 +197,7 @@ class S3DataBackend(
     def _read_bytes(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> Iterator[bytes]:
@@ -225,7 +225,7 @@ class S3DataBackend(
     def _read_dicts(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
     ) -> Iterator[dict]:
@@ -251,7 +251,7 @@ class S3DataBackend(
             }
         )
 
-    def _get_object(self, bucket: Optional[str], key: str) -> dict:
+    def _get_object(self, bucket: str | None, key: str) -> dict:
         """Validate bucket (target) and key (query) and return the S3 object."""
         if not bucket:
             msg = "The target bucket is not set"
@@ -276,11 +276,11 @@ class S3DataBackend(
 
     def write(
         self,
-        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        data: IOBase | Iterable[bytes] | Iterable[dict],
+        target: str | None = None,
+        chunk_size: int | None = None,
         ignore_errors: bool = False,
-        operation_type: Optional[BaseOperationType] = None,
+        operation_type: BaseOperationType | None = None,
     ) -> int:
         """Write `data` records to the `target` bucket and return their count.
 
@@ -315,8 +315,8 @@ class S3DataBackend(
 
     def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
         operation_type: BaseOperationType,
@@ -329,7 +329,7 @@ class S3DataBackend(
     def _write_bytes(
         self,
         data: Iterable[bytes],
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
         operation_type: BaseOperationType,
@@ -407,7 +407,7 @@ class S3DataBackend(
             raise BackendException(msg % error) from error
 
     @staticmethod
-    def _count(statements: Iterable, counter: dict) -> Iterator:
+    def _count(statements: Iterable, counter: Mapping) -> Iterator:
         """Count the elements in the `statements` Iterable and yield element."""
         for statement in statements:
             yield statement

--- a/src/ralph/backends/data/swift.py
+++ b/src/ralph/backends/data/swift.py
@@ -1,9 +1,10 @@
 """Swift data backend for Ralph."""
 
 import logging
+from collections.abc import Iterable, Iterator, Mapping
 from functools import cached_property
 from io import IOBase
-from typing import Any, Iterable, Iterator, Optional, Tuple, Union
+from typing import Any
 from uuid import uuid4
 
 from pydantic import PositiveInt
@@ -52,16 +53,16 @@ class SwiftDataBackendSettings(BaseDataBackendSettings):
     }
 
     AUTH_URL: str = "https://auth.cloud.ovh.net/"
-    DEFAULT_CONTAINER: Optional[str] = None
+    DEFAULT_CONTAINER: str | None = None
     IDENTITY_API_VERSION: str = "3"
-    OBJECT_STORAGE_URL: Optional[str] = None
-    PASSWORD: Optional[str] = None
+    OBJECT_STORAGE_URL: str | None = None
+    PASSWORD: str | None = None
     PROJECT_DOMAIN_NAME: str = "Default"
     READ_CHUNK_SIZE: int = 4096
-    REGION_NAME: Optional[str] = None
-    TENANT_ID: Optional[str] = None
-    TENANT_NAME: Optional[str] = None
-    USERNAME: Optional[str] = None
+    REGION_NAME: str | None = None
+    TENANT_ID: str | None = None
+    TENANT_NAME: str | None = None
+    USERNAME: str | None = None
     USER_DOMAIN_NAME: str = "Default"
     WRITE_CHUNK_SIZE: int = 4096
 
@@ -82,7 +83,7 @@ class SwiftDataBackend(
         BaseOperationType.UPDATE,
     }
 
-    def __init__(self, settings: Optional[SwiftDataBackendSettings] = None):
+    def __init__(self, settings: SwiftDataBackendSettings | None = None):
         """Prepares the options for the SwiftService."""
         super().__init__(settings)
         self.default_container = self.settings.DEFAULT_CONTAINER
@@ -130,8 +131,8 @@ class SwiftDataBackend(
         return DataBackendStatus.OK
 
     def list(
-        self, target: Optional[str] = None, details: bool = False, new: bool = False
-    ) -> Union[Iterator[str], Iterator[dict]]:
+        self, target: str | None = None, details: bool = False, new: bool = False
+    ) -> Iterator[str] | Iterator[dict]:
         """List files for the target container.
 
         Args:
@@ -170,13 +171,13 @@ class SwiftDataBackend(
 
     def read(  # noqa: PLR0913
         self,
-        query: Optional[str] = None,
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        query: str | None = None,
+        target: str | None = None,
+        chunk_size: int | None = None,
         raw_output: bool = False,
         ignore_errors: bool = False,
-        max_statements: Optional[PositiveInt] = None,
-    ) -> Union[Iterator[bytes], Iterator[dict]]:
+        max_statements: PositiveInt | None = None,
+    ) -> Iterator[bytes] | Iterator[dict]:
         """Read objects matching the `query` in the `target` container and yield them.
 
         Args:
@@ -213,7 +214,7 @@ class SwiftDataBackend(
     def _read_bytes(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
     ) -> Iterator[bytes]:
@@ -241,7 +242,7 @@ class SwiftDataBackend(
     def _read_dicts(
         self,
         query: str,
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
     ) -> Iterator[dict]:
@@ -262,8 +263,8 @@ class SwiftDataBackend(
         )
 
     def _get_object(
-        self, container: Optional[str], obj: Optional[str], chunk_size: int
-    ) -> Tuple[dict, Any]:
+        self, container: str | None, obj: str | None, chunk_size: int
+    ) -> tuple[dict, Any]:
         """Validate container and obj and return Swift object wrapping the exception."""
         if not container:
             msg = "The target container is not set"
@@ -288,11 +289,11 @@ class SwiftDataBackend(
 
     def write(
         self,
-        data: Union[IOBase, Iterable[bytes], Iterable[dict]],
-        target: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        data: IOBase | Iterable[bytes] | Iterable[dict],
+        target: str | None = None,
+        chunk_size: int | None = None,
         ignore_errors: bool = False,
-        operation_type: Optional[BaseOperationType] = None,
+        operation_type: BaseOperationType | None = None,
     ) -> int:
         """Write `data` records to the `target` container and returns their count.
 
@@ -321,8 +322,8 @@ class SwiftDataBackend(
 
     def _write_dicts(
         self,
-        data: Iterable[dict],
-        target: Optional[str],
+        data: Iterable[Mapping],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,
         operation_type: BaseOperationType,
@@ -335,7 +336,7 @@ class SwiftDataBackend(
     def _write_bytes(
         self,
         data: Iterable[bytes],
-        target: Optional[str],
+        target: str | None,
         chunk_size: int,
         ignore_errors: bool,  # noqa: ARG002
         operation_type: BaseOperationType,
@@ -425,7 +426,7 @@ class SwiftDataBackend(
         }
 
     @staticmethod
-    def _count(statements: Iterable, counter: dict) -> Iterator:
+    def _count(statements: Iterable, counter: Mapping) -> Iterator:
         """Count the elements in the `statements` Iterable and yield element."""
         for statement in statements:
             yield statement

--- a/src/ralph/backends/loader.py
+++ b/src/ralph/backends/loader.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from functools import lru_cache
-from typing import Dict, Tuple
 
 if sys.version_info < (3, 10):
     from importlib_metadata import EntryPoints, entry_points
@@ -24,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_backends(
-    backends: EntryPoints, base_backends: Tuple[type, ...]
-) -> Dict[str, type]:
+    backends: EntryPoints, base_backends: tuple[type, ...]
+) -> dict[str, type]:
     """Return sub-classes of `base_backends` from `backends`.
 
     Args:
@@ -58,7 +57,7 @@ def get_backends(
 
 
 @lru_cache(maxsize=1)
-def get_cli_backends() -> Dict[str, type]:
+def get_cli_backends() -> dict[str, type]:
     """Return Ralph's backend classes for cli usage."""
     base_backends = (BaseAsyncDataBackend, BaseDataBackend)
     data_backends = entry_points(group="ralph.backends.data")
@@ -66,7 +65,7 @@ def get_cli_backends() -> Dict[str, type]:
 
 
 @lru_cache(maxsize=1)
-def get_cli_write_backends() -> Dict[str, type]:
+def get_cli_write_backends() -> dict[str, type]:
     """Return Ralph's backends classes for cli write usage."""
     return {
         name: backend
@@ -76,7 +75,7 @@ def get_cli_write_backends() -> Dict[str, type]:
 
 
 @lru_cache(maxsize=1)
-def get_cli_list_backends() -> Dict[str, type]:
+def get_cli_list_backends() -> dict[str, type]:
     """Return Ralph's backends classes for cli list usage."""
     return {
         name: backend
@@ -86,7 +85,7 @@ def get_cli_list_backends() -> Dict[str, type]:
 
 
 @lru_cache(maxsize=1)
-def get_lrs_backends() -> Dict[str, type]:
+def get_lrs_backends() -> dict[str, type]:
     """Return Ralph's backend classes for LRS usage."""
     lrs_backends = entry_points(group="ralph.backends.lrs")
     return get_backends(lrs_backends, (BaseAsyncLRSBackend, BaseLRSBackend))

--- a/src/ralph/backends/loader.py
+++ b/src/ralph/backends/loader.py
@@ -1,13 +1,8 @@
 """Ralph backend loader."""
 
 import logging
-import sys
 from functools import lru_cache
-
-if sys.version_info < (3, 10):
-    from importlib_metadata import EntryPoints, entry_points
-else:
-    from importlib.metadata import EntryPoints, entry_points
+from importlib.metadata import EntryPoints, entry_points
 
 from ralph.backends.data.base import (
     AsyncListable,

--- a/src/ralph/backends/lrs/async_es.py
+++ b/src/ralph/backends/lrs/async_es.py
@@ -1,7 +1,7 @@
 """Asynchronous Elasticsearch LRS backend for Ralph."""
 
 import logging
-from typing import AsyncIterator, List, Optional
+from collections.abc import AsyncIterator, Sequence
 
 from ralph.backends.data.async_es import AsyncESDataBackend
 from ralph.backends.lrs.base import (
@@ -19,7 +19,7 @@ class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBa
     """Asynchronous Elasticsearch LRS backend implementation."""
 
     async def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
         query = ESLRSBackend.get_query(params=params)
@@ -41,7 +41,7 @@ class AsyncESLRSBackend(BaseAsyncLRSBackend[ESLRSBackendSettings], AsyncESDataBa
         )
 
     async def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> AsyncIterator[dict]:
         """Yield statements with matching ids from the backend."""
         query = self.query_class(query={"terms": {"_id": ids}})

--- a/src/ralph/backends/lrs/async_mongo.py
+++ b/src/ralph/backends/lrs/async_mongo.py
@@ -1,7 +1,7 @@
 """Async MongoDB LRS backend for Ralph."""
 
 import logging
-from typing import AsyncIterator, List, Optional
+from collections.abc import AsyncIterator, Sequence
 
 from ralph.backends.data.async_mongo import AsyncMongoDataBackend
 from ralph.backends.lrs.base import (
@@ -21,7 +21,7 @@ class AsyncMongoLRSBackend(
     """Async MongoDB LRS backend implementation."""
 
     async def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
         query = MongoLRSBackend.get_query(params)
@@ -47,7 +47,7 @@ class AsyncMongoLRSBackend(
         )
 
     async def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> AsyncIterator[dict]:
         """Yield statements with matching ids from the backend."""
         query = self.query_class(filter={"_source.id": {"$in": ids}})

--- a/src/ralph/backends/lrs/base.py
+++ b/src/ralph/backends/lrs/base.py
@@ -1,23 +1,19 @@
 """Base LRS backend for Ralph."""
 
 from abc import abstractmethod
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
+    Annotated,
     Any,
-    AsyncIterator,
-    Iterator,
-    List,
     Literal,
-    Optional,
     TypeVar,
-    Union,
 )
 from uuid import UUID
 
 from pydantic import AfterValidator, BaseModel, Field, NonNegativeInt
 from pydantic_settings import SettingsConfigDict
-from typing_extensions import Annotated
 
 from ralph.backends.data.base import (
     BaseAsyncDataBackend,
@@ -44,12 +40,12 @@ class BaseLRSBackendSettings(BaseDataBackendSettings):
 class StatementQueryResult:
     """Result of an LRS statements query."""
 
-    statements: List[dict]
-    pit_id: Optional[str] = None
-    search_after: Optional[str] = None
+    statements: Sequence[Mapping]
+    pit_id: str | None = None
+    search_after: str | None = None
 
 
-def validate_iso_datetime_str(value: Union[str, datetime]) -> datetime:
+def validate_iso_datetime_str(value: str | datetime) -> datetime:
     """Value is expected to be an ISO 8601 date time string.
 
     Note that we also accept datetime python instance that will be converted
@@ -68,9 +64,7 @@ def validate_iso_datetime_str(value: Union[str, datetime]) -> datetime:
         raise ValueError("invalid ISO 8601 date time string") from err
 
 
-IsoDatetimeStr = Annotated[
-    Union[str, datetime], AfterValidator(validate_iso_datetime_str)
-]
+IsoDatetimeStr = Annotated[str | datetime, AfterValidator(validate_iso_datetime_str)]
 
 
 class LRSStatementsQuery(BaseQuery):
@@ -80,22 +74,20 @@ class LRSStatementsQuery(BaseQuery):
     https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI-Communication.md#213-get-statements
     """
 
-    statement_id: Annotated[Optional[str], Field(alias="statementId")] = None
-    voided_statement_id: Annotated[Optional[str], Field(alias="voidedStatementId")] = (
-        None
-    )
-    agent: Optional[Union[BaseXapiAgent, BaseXapiGroup]] = None
-    verb: Optional[IRI] = None
-    activity: Optional[IRI] = None
-    registration: Optional[UUID] = None
-    related_activities: Optional[bool] = False
-    related_agents: Optional[bool] = False
-    since: Optional[IsoDatetimeStr] = None
-    until: Optional[IsoDatetimeStr] = None
-    limit: Optional[NonNegativeInt] = 0
-    format: Optional[Literal["ids", "exact", "canonical"]] = "exact"
-    attachments: Optional[bool] = False
-    ascending: Optional[bool] = False
+    statement_id: Annotated[str | None, Field(alias="statementId")] = None
+    voided_statement_id: Annotated[str | None, Field(alias="voidedStatementId")] = None
+    agent: BaseXapiAgent | BaseXapiGroup | None = None
+    verb: IRI | None = None
+    activity: IRI | None = None
+    registration: UUID | None = None
+    related_activities: bool | None = False
+    related_agents: bool | None = False
+    since: IsoDatetimeStr | None = None
+    until: IsoDatetimeStr | None = None
+    limit: NonNegativeInt | None = 0
+    format: Literal["ids", "exact", "canonical"] | None = "exact"
+    attachments: bool | None = False
+    ascending: bool | None = False
 
 
 class AgentParameters(BaseModel):
@@ -104,21 +96,21 @@ class AgentParameters(BaseModel):
     NB: Agent refers to the data structure, NOT to the LRS query parameter.
     """
 
-    mbox: Optional[str] = None
-    mbox_sha1sum: Optional[str] = None
-    openid: Optional[str] = None
-    account__name: Optional[str] = None
-    account__home_page: Optional[str] = None
+    mbox: str | None = None
+    mbox_sha1sum: str | None = None
+    openid: str | None = None
+    account__name: str | None = None
+    account__home_page: str | None = None
 
 
 class RalphStatementsQuery(LRSStatementsQuery):
     """Represents a dictionary of possible LRS query parameters."""
 
-    agent: Optional[AgentParameters] = AgentParameters.model_construct()
-    search_after: Optional[str] = None
-    pit_id: Optional[str] = None
-    authority: Optional[AgentParameters] = AgentParameters.model_construct()
-    ignore_order: Optional[bool] = None
+    agent: AgentParameters | None = AgentParameters.model_construct()
+    search_after: str | None = None
+    pit_id: str | None = None
+    authority: AgentParameters | None = AgentParameters.model_construct()
+    ignore_order: bool | None = None
 
 
 Settings = TypeVar("Settings", bound=BaseLRSBackendSettings)
@@ -129,13 +121,13 @@ class BaseLRSBackend(BaseDataBackend[Settings, Any]):
 
     @abstractmethod
     def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
 
     @abstractmethod
     def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
 
@@ -145,12 +137,12 @@ class BaseAsyncLRSBackend(BaseAsyncDataBackend[Settings, Any]):
 
     @abstractmethod
     async def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
 
     @abstractmethod
     async def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> AsyncIterator[dict]:
         """Return the list of matching statement IDs from the database."""

--- a/src/ralph/backends/lrs/clickhouse.py
+++ b/src/ralph/backends/lrs/clickhouse.py
@@ -1,7 +1,7 @@
 """ClickHouse LRS backend for Ralph."""
 
 import logging
-from typing import Generator, Iterator, List, Optional
+from collections.abc import Generator, Iterator, Mapping, Sequence
 
 from pydantic_settings import SettingsConfigDict
 
@@ -45,7 +45,7 @@ class ClickHouseLRSBackend(
     """ClickHouse LRS backend implementation."""
 
     def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
         ch_params = params.model_dump(exclude_none=True)
@@ -130,7 +130,7 @@ class ClickHouseLRSBackend(
         )
 
     def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
 
@@ -160,16 +160,16 @@ class ClickHouseLRSBackend(
 
     @staticmethod
     def _add_agent_filters(
-        ch_params: dict,
-        where: list,
-        agent_params: AgentParameters,
+        ch_params: Mapping,
+        where: Sequence,
+        agent_params: AgentParameters | Mapping,
         target_field: str,
     ) -> None:
         """Add filters relative to agents to `where`."""
         if not agent_params:
             return
 
-        if not isinstance(agent_params, dict):
+        if not isinstance(agent_params, Mapping):
             agent_params = agent_params.model_dump()
 
         if agent_params.get("mbox"):

--- a/src/ralph/backends/lrs/cozystack.py
+++ b/src/ralph/backends/lrs/cozystack.py
@@ -1,8 +1,8 @@
 """CozyStack LRS backend for Ralph."""
 
 import logging
+from collections.abc import Iterator, Mapping, Sequence
 from enum import StrEnum
-from typing import Iterator, List, Optional
 
 from pydantic_settings import SettingsConfigDict
 
@@ -47,7 +47,9 @@ class CozyStackLRSBackend(
 
     @staticmethod
     def _add_agent_filters(
-        query_filters: dict, agent_params: AgentParameters, target_field: str
+        query_filters: Mapping,
+        agent_params: AgentParameters | Mapping,
+        target_field: str,
     ) -> None:
         """Add filters relative to agents to cozystack_query_filters.
 
@@ -59,7 +61,7 @@ class CozyStackLRSBackend(
         if not agent_params:
             return
 
-        if not isinstance(agent_params, dict):
+        if not isinstance(agent_params, Mapping):
             agent_params = agent_params.model_dump()
 
         prefix = f"source.{target_field}"
@@ -124,7 +126,7 @@ class CozyStackLRSBackend(
         )
 
     def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the results of a statements query using xAPI parameters."""
         query = self.get_query(params)
@@ -146,7 +148,7 @@ class CozyStackLRSBackend(
         )
 
     def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
         query = self.query_class(selector={"source.id": {"$in": ids}})

--- a/src/ralph/backends/lrs/es.py
+++ b/src/ralph/backends/lrs/es.py
@@ -1,7 +1,7 @@
 """Elasticsearch LRS backend for Ralph."""
 
 import logging
-from typing import Iterator, List, Optional
+from collections.abc import Iterator, Mapping, Sequence
 
 from pydantic_settings import SettingsConfigDict
 
@@ -37,7 +37,7 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
     """Elasticsearch LRS backend implementation."""
 
     def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the statements query payload using xAPI parameters."""
         query = self.get_query(params=params)
@@ -57,7 +57,7 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
         )
 
     def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
         query = self.query_class(query={"terms": {"_id": ids}})
@@ -112,13 +112,15 @@ class ESLRSBackend(BaseLRSBackend[ESLRSBackendSettings], ESDataBackend):
 
     @staticmethod
     def _add_agent_filters(
-        es_query_filters: list, agent_params: AgentParameters, target_field: str
+        es_query_filters: Sequence,
+        agent_params: AgentParameters | Mapping,
+        target_field: str,
     ) -> None:
         """Add filters relative to agents to `es_query_filters`."""
         if not agent_params:
             return
 
-        if not isinstance(agent_params, dict):
+        if not isinstance(agent_params, Mapping):
             agent_params = agent_params.model_dump()
 
         if agent_params.get("mbox"):

--- a/src/ralph/backends/lrs/mongo.py
+++ b/src/ralph/backends/lrs/mongo.py
@@ -1,7 +1,7 @@
 """MongoDB LRS backend for Ralph."""
 
 import logging
-from typing import Iterator, List, Optional
+from collections.abc import Iterator, Mapping, Sequence
 
 from bson.objectid import ObjectId
 from pydantic_settings import SettingsConfigDict
@@ -38,7 +38,7 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
     """MongoDB LRS backend."""
 
     def query_statements(
-        self, params: RalphStatementsQuery, target: Optional[str] = None
+        self, params: RalphStatementsQuery, target: str | None = None
     ) -> StatementQueryResult:
         """Return the results of a statements query using xAPI parameters."""
         query = self.get_query(params)
@@ -61,7 +61,7 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
         )
 
     def query_statements_by_ids(
-        self, ids: List[str], target: Optional[str] = None
+        self, ids: Sequence[str], target: str | None = None
     ) -> Iterator[dict]:
         """Yield statements with matching ids from the backend."""
         query = self.query_class(filter={"_source.id": {"$in": ids}})
@@ -122,7 +122,9 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
 
     @staticmethod
     def _add_agent_filters(
-        mongo_query_filters: dict, agent_params: AgentParameters, target_field: str
+        mongo_query_filters: Mapping,
+        agent_params: AgentParameters | Mapping,
+        target_field: str,
     ) -> None:
         """Add filters relative to agents to mongo_query_filters.
 
@@ -134,7 +136,7 @@ class MongoLRSBackend(BaseLRSBackend[MongoLRSBackendSettings], MongoDataBackend)
         if not agent_params:
             return
 
-        if not isinstance(agent_params, dict):
+        if not isinstance(agent_params, Mapping):
             agent_params = agent_params.model_dump()
 
         if agent_params.get("mbox"):

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -4,10 +4,11 @@ import json
 import logging
 import re
 import sys
+from collections.abc import Callable, Mapping
 from inspect import isasyncgen, isclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Type
 
 import bcrypt
 from pydantic import AnyHttpUrl, MongoDsn
@@ -197,11 +198,11 @@ class JSONStringParamType(click.ParamType):
 class RalphCLI(click.Group):
     """Ralph CLI entrypoint."""
 
-    lazy_commands: Dict[str, Callable] = {}
+    lazy_commands: Mapping[str, Callable] = {}
 
     @classmethod
     def lazy_backends_options(
-        cls, get_backends: Callable, name: Optional[str] = None
+        cls, get_backends: Callable, name: str | None = None
     ) -> Callable:
         """Lazy backend-related options decorator for Ralph commands."""
 
@@ -232,7 +233,7 @@ class RalphCLI(click.Group):
         self.lazy_commands = {}
         return super().list_commands(ctx)
 
-    def get_command(self, ctx, cmd_name) -> Union[click.Command, None]:
+    def get_command(self, ctx, cmd_name) -> click.Command | None:
         """Register lazy command (if it is requested) before calling `get_command`."""
         if cmd_name in self.lazy_commands:
             self.lazy_commands[cmd_name]()
@@ -260,8 +261,8 @@ def cli(verbosity=None):
     """
 
 
-# Once we have a base backend interface we could use Dict[str, Type[BaseBackend]]
-def backends_options(backends: Dict[str, Type], name: Optional[str] = None):
+# Once we have a base backend interface we could use Mapping[str, Type[BaseBackend]]
+def backends_options(backends: Mapping[str, Type], name: str | None = None):
     """Backend-related options decorator for Ralph commands."""
 
     def wrapper(command):

--- a/src/ralph/conf.py
+++ b/src/ralph/conf.py
@@ -1,9 +1,10 @@
 """Configurations for Ralph."""
 
 import io
+from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Annotated
 
 from pydantic import (
     AfterValidator,
@@ -17,7 +18,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing_extensions import Annotated
 
 from ralph.exceptions import ConfigurationException
 from ralph.utils import import_string
@@ -55,7 +55,7 @@ class CoreSettings(BaseSettings):
 core_settings = CoreSettings()
 
 
-def validate_comma_separated_tuple(value: Union[str, Tuple[str, ...]]) -> Tuple[str]:
+def validate_comma_separated_tuple(value: str | tuple[str, ...]) -> tuple[str]:
     """Checks whether the value is a comma separated string or a tuple."""
     if isinstance(value, tuple):
         return value
@@ -67,7 +67,7 @@ def validate_comma_separated_tuple(value: Union[str, Tuple[str, ...]]) -> Tuple[
 
 
 CommaSeparatedTuple = Annotated[
-    Union[str, Tuple[str, ...]], AfterValidator(validate_comma_separated_tuple)
+    str | tuple[str, ...], AfterValidator(validate_comma_separated_tuple)
 ]
 
 
@@ -133,8 +133,8 @@ class AuthBackend(str, Enum):
 
 
 def validate_auth_backends(
-    value: Union[str, Tuple[str, ...], List[str]]
-) -> Tuple[AuthBackend]:
+    value: str | tuple[str, ...] | Sequence[str]
+) -> tuple[AuthBackend]:
     """Check whether the value is a comma separated string or a list/tuple."""
     if isinstance(value, (tuple, list)):
         return tuple(AuthBackend(val.lower()) for val in value)
@@ -146,7 +146,7 @@ def validate_auth_backends(
 
 
 AuthBackends = Annotated[
-    Union[str, Tuple[str, ...], List[str]], AfterValidator(validate_auth_backends)
+    str | tuple[str, ...] | Sequence[str], AfterValidator(validate_auth_backends)
 ]
 
 
@@ -164,7 +164,7 @@ class Settings(BaseSettings):
     AUTH_FILE: Path = _CORE.APP_DIR / "auth.json"
     AUTH_CACHE_MAX_SIZE: int = 100
     AUTH_CACHE_TTL: int = 3600
-    CONVERTER_EDX_XAPI_UUID_NAMESPACE: Optional[str] = None
+    CONVERTER_EDX_XAPI_UUID_NAMESPACE: str | None = None
     EXECUTION_ENVIRONMENT: str = "development"
     HISTORY_FILE: Path = _CORE.APP_DIR / "history.json"
     LOGGING: dict = {
@@ -202,8 +202,8 @@ class Settings(BaseSettings):
     RUNSERVER_AUTH_BACKENDS: AuthBackends = TypeAdapter(AuthBackends).validate_python(
         "Basic"
     )
-    RUNSERVER_AUTH_OIDC_AUDIENCE: Optional[str] = None
-    RUNSERVER_AUTH_OIDC_ISSUER_URI: Optional[AnyHttpUrl] = None
+    RUNSERVER_AUTH_OIDC_AUDIENCE: str | None = None
+    RUNSERVER_AUTH_OIDC_ISSUER_URI: AnyHttpUrl | None = None
     RUNSERVER_BACKEND: str = "es"
     RUNSERVER_HOST: str = "0.0.0.0"  # noqa: S104
     RUNSERVER_MAX_SEARCH_HITS_COUNT: int = 100
@@ -212,12 +212,12 @@ class Settings(BaseSettings):
     LRS_RESTRICT_BY_AUTHORITY: bool = False
     LRS_RESTRICT_BY_SCOPES: bool = False
     SENTRY_CLI_TRACES_SAMPLE_RATE: float = 1.0
-    SENTRY_DSN: Optional[str] = None
+    SENTRY_DSN: str | None = None
     SENTRY_IGNORE_HEALTH_CHECKS: bool = False
     SENTRY_LRS_TRACES_SAMPLE_RATE: float = 1.0
-    XAPI_FORWARDINGS: List[XapiForwardingConfigurationSettings] = []
+    XAPI_FORWARDINGS: list[XapiForwardingConfigurationSettings] = []
     XAPI_PREFIX: str = "/xAPI"
-    XAPI_VERSIONS_SUPPORTED: List[str] = ["1.0.3"]
+    XAPI_VERSIONS_SUPPORTED: list[str] = ["1.0.3"]
     XAPI_VERSION_FALLBACK: str = "1.0.3"
 
     @property

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -1,11 +1,12 @@
 """Ralph tracking logs filters."""
 
-from typing import Any, Union
+from collections.abc import Mapping
+from typing import Any
 
 from .exceptions import EventKeyError
 
 
-def anonymous(event: dict) -> Union[dict, Any]:
+def anonymous(event: Mapping) -> dict | Any:
     """Remove anonymous events.
 
     Args:

--- a/src/ralph/filters.py
+++ b/src/ralph/filters.py
@@ -6,7 +6,7 @@ from typing import Any
 from .exceptions import EventKeyError
 
 
-def anonymous(event: Mapping) -> dict | Any:
+def anonymous(event: Mapping) -> Any:
     """Remove anonymous events.
 
     Args:

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from pydantic import (
     AnyHttpUrl,
@@ -32,14 +32,14 @@ class ContextModuleField(BaseModelWithConfig):
         str, StringConstraints(pattern=r"^block-v1:.+\+.+\+.+type@.+@[a-f0-9]{32}$")
     ]
     display_name: str
-    original_usage_key: Optional[
+    original_usage_key: (
         Annotated[
             str,
             StringConstraints(
                 pattern=r"^block-v1:.+\+.+\+.+type@problem\+block@[a-f0-9]{32}$"
             ),
         ]
-    ] = None
+    ) | None = None
     original_usage_version: str | None = None
 
 
@@ -47,7 +47,7 @@ class BaseContextField(BaseModelWithConfig):
     """Pydantic model for core `context` field.
 
     Attributes:
-        course_user_tags (Dict of str): Content from `user_api_usercoursetag` table.
+        course_user_tags (dict of str): Content from `user_api_usercoursetag` table.
             Retrieved with::
                 `dict(
                     UserCourseTag.objects.filter(

--- a/src/ralph/models/edx/base.py
+++ b/src/ralph/models/edx/base.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
-from typing import Dict, Literal, Optional, Union
+from typing import Annotated, Literal, Optional
 
 from pydantic import (
     AnyHttpUrl,
@@ -12,7 +12,6 @@ from pydantic import (
     Field,
     StringConstraints,
 )
-from typing_extensions import Annotated
 
 
 class BaseModelWithConfig(BaseModel):
@@ -41,7 +40,7 @@ class ContextModuleField(BaseModelWithConfig):
             ),
         ]
     ] = None
-    original_usage_version: Optional[str] = None
+    original_usage_version: str | None = None
 
 
 class BaseContextField(BaseModelWithConfig):
@@ -87,11 +86,11 @@ class BaseContextField(BaseModelWithConfig):
     """
 
     course_id: Annotated[str, Field(pattern=r"^$|^course-v1:.+\+.+\+.+$")]
-    course_user_tags: Optional[Dict[str, str]] = None
-    module: Optional[ContextModuleField] = None
+    course_user_tags: dict[str, str] | None = None
+    module: ContextModuleField | None = None
     org_id: str
     path: Path
-    user_id: Union[int, Literal[""], None] = None
+    user_id: int | Literal[""] | None = None
 
 
 class AbstractBaseEventField(BaseModelWithConfig):
@@ -156,13 +155,13 @@ class BaseEdxModel(BaseModelWithConfig):
                 In JSON the value is `null` instead of `None`.
     """
 
-    username: Union[
-        Annotated[str, StringConstraints(min_length=2, max_length=30)], Literal[""]
-    ]
-    ip: Union[IPv4Address, Literal[""]]
+    username: (
+        Annotated[str, StringConstraints(min_length=2, max_length=30)] | Literal[""]
+    )
+    ip: IPv4Address | Literal[""]
     agent: str
     host: str
-    referer: Union[AnyHttpUrl, Literal[""]]
+    referer: AnyHttpUrl | Literal[""]
     accept_language: str
     context: BaseContextField
     time: datetime

--- a/src/ralph/models/edx/bookmark/fields/events.py
+++ b/src/ralph/models/edx/bookmark/fields/events.py
@@ -66,7 +66,9 @@ class EdxBookmarkListedEventField(AbstractBaseEventField):
     """
 
     bookmarks_count: int
-    course_id: Annotated[str, StringConstraints(pattern=r"^$|^course-v1:.+\+.+\+.+$")] | None
+    course_id: (
+        Annotated[str, StringConstraints(pattern=r"^$|^course-v1:.+\+.+\+.+$")] | None
+    )
     list_type: Literal["per_course", "all_courses"]
     page_number: int
     page_size: int

--- a/src/ralph/models/edx/bookmark/fields/events.py
+++ b/src/ralph/models/edx/bookmark/fields/events.py
@@ -1,16 +1,10 @@
 """Video event fields definitions."""
 
-import sys
-from typing import Annotated, Optional
+from typing import Annotated, Literal, Optional
 
 from pydantic import StringConstraints
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxBookmarkBaseEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/bookmark/fields/events.py
+++ b/src/ralph/models/edx/bookmark/fields/events.py
@@ -1,10 +1,9 @@
 """Video event fields definitions."""
 
 import sys
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/bookmark/fields/events.py
+++ b/src/ralph/models/edx/bookmark/fields/events.py
@@ -1,6 +1,6 @@
 """Video event fields definitions."""
 
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from pydantic import StringConstraints
 
@@ -66,9 +66,7 @@ class EdxBookmarkListedEventField(AbstractBaseEventField):
     """
 
     bookmarks_count: int
-    course_id: Optional[
-        Annotated[str, StringConstraints(pattern=r"^$|^course-v1:.+\+.+\+.+$")]
-    ]
+    course_id: Annotated[str, StringConstraints(pattern=r"^$|^course-v1:.+\+.+\+.+$")] | None
     list_type: Literal["per_course", "all_courses"]
     page_number: int
     page_size: int

--- a/src/ralph/models/edx/bookmark/statements.py
+++ b/src/ralph/models/edx/bookmark/statements.py
@@ -1,6 +1,6 @@
 """Bookmark event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -15,11 +15,6 @@ from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UIEdxBookmarkAccessed(BaseBrowserModel):

--- a/src/ralph/models/edx/bookmark/statements.py
+++ b/src/ralph/models/edx/bookmark/statements.py
@@ -1,7 +1,6 @@
 """Bookmark event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -37,10 +36,7 @@ class UIEdxBookmarkAccessed(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="edx.bookmark.accessed")
 
-    event: Union[
-        Json[EdxBookmarkBaseEventField],
-        EdxBookmarkBaseEventField,
-    ]
+    event: Json[EdxBookmarkBaseEventField] | EdxBookmarkBaseEventField
     event_type: Literal["edx.bookmark.accessed"]
     name: Literal["edx.bookmark.accessed"]
 
@@ -58,10 +54,8 @@ class EdxBookmarkAdded(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.bookmark.added")
 
-    event: Union[
-        Json[EdxBookmarkAddedEventField],
-        EdxBookmarkAddedEventField,
-    ]
+    event: Json[EdxBookmarkAddedEventField] | EdxBookmarkAddedEventField
+
     event_type: Literal["edx.bookmark.added"]
     name: Literal["edx.bookmark.added"]
 
@@ -81,10 +75,8 @@ class EdxBookmarkListed(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.bookmark.listed")
 
-    event: Union[
-        Json[EdxBookmarkListedEventField],
-        EdxBookmarkListedEventField,
-    ]
+    event: Json[EdxBookmarkListedEventField] | EdxBookmarkListedEventField
+
     event_type: Literal["edx.bookmark.listed"]
     name: Literal["edx.bookmark.listed"]
 
@@ -102,10 +94,7 @@ class EdxBookmarkRemoved(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.bookmark.removed")
 
-    event: Union[
-        Json[EdxBookmarkRemovedEventField],
-        EdxBookmarkRemovedEventField,
-    ]
+    event: Json[EdxBookmarkRemovedEventField] | EdxBookmarkRemovedEventField
     event_type: Literal["edx.bookmark.removed"]
     name: Literal["edx.bookmark.removed"]
 
@@ -127,9 +116,6 @@ class UIEdxCourseToolAccessed(BaseBrowserModel):
         event_source="browser", event_type="edx.course.tool.accessed"
     )
 
-    event: Union[
-        Json[UIEdxCourseToolAccessedEventField],
-        UIEdxCourseToolAccessedEventField,
-    ]
+    event: Json[UIEdxCourseToolAccessedEventField] | UIEdxCourseToolAccessedEventField
     event_type: Literal["edx.course.tool.accessed"]
     name: Literal["edx.course.tool.accessed"]

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,16 +1,10 @@
 """Browser event model definitions."""
 
-import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import AnyUrl, StringConstraints
 
 from .base import BaseEdxModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class BaseBrowserModel(BaseEdxModel):

--- a/src/ralph/models/edx/browser.py
+++ b/src/ralph/models/edx/browser.py
@@ -1,10 +1,9 @@
 """Browser event model definitions."""
 
 import sys
-from typing import Union
+from typing import Annotated
 
 from pydantic import AnyUrl, StringConstraints
-from typing_extensions import Annotated
 
 from .base import BaseEdxModel
 
@@ -30,6 +29,4 @@ class BaseBrowserModel(BaseEdxModel):
 
     event_source: Literal["browser"]
     page: AnyUrl
-    session: Union[
-        Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}$")], Literal[""]
-    ]
+    session: Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{32}$")] | Literal[""]

--- a/src/ralph/models/edx/certificate/fields/events.py
+++ b/src/ralph/models/edx/certificate/fields/events.py
@@ -1,17 +1,11 @@
 """Cohort event field definition."""
 
-import sys
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import AnyHttpUrl, StringConstraints
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class CertificateBaseEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/certificate/fields/events.py
+++ b/src/ralph/models/edx/certificate/fields/events.py
@@ -1,10 +1,10 @@
 """Cohort event field definition."""
 
 import sys
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import AnyHttpUrl, StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/certificate/statements.py
+++ b/src/ralph/models/edx/certificate/statements.py
@@ -1,6 +1,6 @@
 """Certificate events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -14,11 +14,6 @@ from .fields.events import (
     EdxCertificateRevokedEventField,
     EdxCertificateSharedEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxCertificateCreated(BaseServerModel):

--- a/src/ralph/models/edx/certificate/statements.py
+++ b/src/ralph/models/edx/certificate/statements.py
@@ -1,7 +1,6 @@
 """Certificate events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -32,10 +31,7 @@ class EdxCertificateCreated(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.certificate.created")
 
-    event: Union[
-        Json[EdxCertificateCreatedEventField],
-        EdxCertificateCreatedEventField,
-    ]
+    event: Json[EdxCertificateCreatedEventField] | EdxCertificateCreatedEventField
     event_type: Literal["edx.certificate.created"]
     name: Literal["edx.certificate.created"]
 
@@ -50,10 +46,7 @@ class EdxCertificateRevoked(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.certificate.revoked")
 
-    event: Union[
-        Json[EdxCertificateRevokedEventField],
-        EdxCertificateRevokedEventField,
-    ]
+    event: Json[EdxCertificateRevokedEventField] | EdxCertificateRevokedEventField
     event_type: Literal["edx.certificate.revoked"]
     name: Literal["edx.certificate.revoked"]
 
@@ -68,10 +61,8 @@ class EdxCertificateShared(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.certificate.shared")
 
-    event: Union[
-        Json[EdxCertificateSharedEventField],
-        EdxCertificateSharedEventField,
-    ]
+    event: Json[EdxCertificateSharedEventField] | EdxCertificateSharedEventField
+
     event_type: Literal["edx.certificate.shared"]
     name: Literal["edx.certificate.shared"]
 
@@ -88,10 +79,10 @@ class EdxCertificateEvidenceVisited(BaseServerModel):
         event_source="server", event_type="edx.certificate.evidence_visited"
     )
 
-    event: Union[
-        Json[EdxCertificateEvidenceVisitedEventField],
-        EdxCertificateEvidenceVisitedEventField,
-    ]
+    event: (
+        Json[EdxCertificateEvidenceVisitedEventField]
+        | EdxCertificateEvidenceVisitedEventField
+    )
     event_type: Literal["edx.certificate.evidence_visited"]
     name: Literal["edx.certificate.evidence_visited"]
 
@@ -108,10 +99,9 @@ class EdxCertificateGenerationEnabled(BaseServerModel):
         event_source="server", event_type="edx.certificate.generation.enabled"
     )
 
-    event: Union[
-        Json[CertificateGenerationBaseEventField],
-        CertificateGenerationBaseEventField,
-    ]
+    event: (
+        Json[CertificateGenerationBaseEventField] | CertificateGenerationBaseEventField
+    )
     event_type: Literal["edx.certificate.generation.enabled"]
     name: Literal["edx.certificate.generation.enabled"]
 
@@ -128,9 +118,6 @@ class EdxCertificateGenerationDisabled(BaseServerModel):
         event_source="server", event_type="edx.certificate.generation.disabled"
     )
 
-    event: Union[
-        Json[CertificateGenerationBaseEventField],
-        CertificateGenerationBaseEventField,
-    ]
+    event: CertificateGenerationBaseEventField | CertificateGenerationBaseEventField
     event_type: Literal["edx.certificate.generation.disabled"]
     name: Literal["edx.certificate.generation.disabled"]

--- a/src/ralph/models/edx/cohort/statements.py
+++ b/src/ralph/models/edx/cohort/statements.py
@@ -1,6 +1,6 @@
 """Cohort events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -8,11 +8,6 @@ from ralph.models.selector import selector
 
 from ..server import BaseServerModel
 from .fields.events import CohortBaseEventField, CohortUserBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxCohortCreated(BaseServerModel):

--- a/src/ralph/models/edx/cohort/statements.py
+++ b/src/ralph/models/edx/cohort/statements.py
@@ -1,7 +1,6 @@
 """Cohort events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -28,10 +27,7 @@ class EdxCohortCreated(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.cohort.created")
 
-    event: Union[
-        Json[CohortBaseEventField],
-        CohortBaseEventField,
-    ]
+    event: Json[CohortBaseEventField] | CohortBaseEventField
     event_type: Literal["edx.cohort.created"]
     name: Literal["edx.cohort.created"]
 
@@ -48,10 +44,7 @@ class EdxCohortUserAdded(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.cohort.user_added")
 
-    event: Union[
-        Json[CohortUserBaseEventField],
-        CohortUserBaseEventField,
-    ]
+    event: Json[CohortUserBaseEventField] | CohortUserBaseEventField
     event_type: Literal["edx.cohort.user_added"]
     name: Literal["edx.cohort.user_added"]
 
@@ -70,9 +63,6 @@ class EdxCohortUserRemoved(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.cohort.user_removed")
 
-    event: Union[
-        Json[CohortUserBaseEventField],
-        CohortUserBaseEventField,
-    ]
+    event: Json[CohortUserBaseEventField] | CohortUserBaseEventField
     event_type: Literal["edx.cohort.user_removed"]
     name: Literal["edx.cohort.user_removed"]

--- a/src/ralph/models/edx/content_library_interaction/fields/events.py
+++ b/src/ralph/models/edx/content_library_interaction/fields/events.py
@@ -1,7 +1,6 @@
 """Video event fields definitions."""
 
 import sys
-from typing import List, Optional
 
 from pydantic import PositiveInt
 
@@ -26,7 +25,7 @@ class EdxLibraryContentBlockContentComponent(BaseModelWithConfig):
         usage_key (str): Consists of the location of this component in the course.
     """  # noqa: D205
 
-    descendants: Optional[list] = None
+    descendants: list | None = None
     original_usage_key: str
     original_usage_version: str
     usage_key: str
@@ -50,7 +49,7 @@ class ContentLibraryInteractionBaseEventField(AbstractBaseEventField):
     location: str
     max_count: PositiveInt
     previous_count: PositiveInt
-    result: List[EdxLibraryContentBlockContentComponent]
+    result: list[EdxLibraryContentBlockContentComponent]
 
 
 class EdxLibraryContentBlockContentAssignedEventField(
@@ -64,7 +63,7 @@ class EdxLibraryContentBlockContentAssignedEventField(
             EdxLibraryContentBlockContentComponent for more information.
     """
 
-    added: List[EdxLibraryContentBlockContentComponent]
+    added: list[EdxLibraryContentBlockContentComponent]
 
 
 class EdxLibraryContentBlockContentRemovedEventField(
@@ -83,4 +82,4 @@ class EdxLibraryContentBlockContentRemovedEventField(
     """
 
     reason: Literal["overlimit", "invalid"]
-    removed: List[EdxLibraryContentBlockContentComponent]
+    removed: list[EdxLibraryContentBlockContentComponent]

--- a/src/ralph/models/edx/content_library_interaction/fields/events.py
+++ b/src/ralph/models/edx/content_library_interaction/fields/events.py
@@ -1,15 +1,10 @@
 """Video event fields definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import PositiveInt
 
 from ...base import AbstractBaseEventField, BaseModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxLibraryContentBlockContentComponent(BaseModelWithConfig):

--- a/src/ralph/models/edx/content_library_interaction/statements.py
+++ b/src/ralph/models/edx/content_library_interaction/statements.py
@@ -1,6 +1,6 @@
 """Content library interaction event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -11,11 +11,6 @@ from ralph.models.edx.content_library_interaction.fields.events import (
 from ralph.models.selector import selector
 
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxLibraryContentBlockContentAssigned(BaseServerModel):

--- a/src/ralph/models/edx/content_library_interaction/statements.py
+++ b/src/ralph/models/edx/content_library_interaction/statements.py
@@ -1,7 +1,6 @@
 """Content library interaction event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -38,10 +37,10 @@ class EdxLibraryContentBlockContentAssigned(BaseServerModel):
         event_source="server", event_type="edx.librarycontentblock.content.assigned"
     )
 
-    event: Union[
-        Json[EdxLibraryContentBlockContentAssignedEventField],
-        EdxLibraryContentBlockContentAssignedEventField,
-    ]
+    event: (
+        Json[EdxLibraryContentBlockContentAssignedEventField]
+        | EdxLibraryContentBlockContentAssignedEventField
+    )
     event_type: Literal["edx.librarycontentblock.content.assigned"]
     name: Literal["edx.librarycontentblock.content.assigned"]
 
@@ -65,9 +64,9 @@ class EdxLibraryContentBlockContentRemoved(BaseServerModel):
         event_source="server", event_type="edx.librarycontentblock.content.removed"
     )
 
-    event: Union[
-        Json[EdxLibraryContentBlockContentRemovedEventField],
-        EdxLibraryContentBlockContentRemovedEventField,
-    ]
+    event: (
+        Json[EdxLibraryContentBlockContentRemovedEventField]
+        | EdxLibraryContentBlockContentRemovedEventField
+    )
     event_type: Literal["edx.librarycontentblock.content.removed"]
     name: Literal["edx.librarycontentblock.content.removed"]

--- a/src/ralph/models/edx/converters/xapi/base.py
+++ b/src/ralph/models/edx/converters/xapi/base.py
@@ -1,6 +1,5 @@
 """Base xAPI Converter."""
 
-from typing import Set
 from uuid import UUID, uuid5
 
 from ralph.exceptions import ConfigurationException
@@ -28,7 +27,7 @@ class BaseXapiConverter(BaseConversionSet):
             raise ConfigurationException("Invalid UUID namespace") from err
         super().__init__()
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         return {
             ConversionItem(

--- a/src/ralph/models/edx/converters/xapi/enrollment.py
+++ b/src/ralph/models/edx/converters/xapi/enrollment.py
@@ -1,7 +1,5 @@
 """Enrollment event xAPI Converter."""
 
-from typing import Set
-
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.enrollment.statements import (
     EdxCourseEnrollmentActivated,
@@ -15,7 +13,7 @@ from .base import BaseXapiConverter
 class LMSBaseXapiConverter(BaseXapiConverter):
     """Base LMS xAPI Converter."""
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/converters/xapi/navigational.py
+++ b/src/ralph/models/edx/converters/xapi/navigational.py
@@ -1,7 +1,5 @@
 """Navigational event xAPI Converter."""
 
-from typing import Set
-
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.navigational.statements import UIPageClose
 from ralph.models.xapi.navigation.statements import PageTerminated
@@ -21,7 +19,7 @@ class UIPageCloseToPageTerminated(BaseXapiConverter):
     __src__ = UIPageClose
     __dest__ = PageTerminated
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union({ConversionItem("object__id", "page")})

--- a/src/ralph/models/edx/converters/xapi/server.py
+++ b/src/ralph/models/edx/converters/xapi/server.py
@@ -1,7 +1,5 @@
 """Server event xAPI Converter."""
 
-from typing import Set
-
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.server import Server
 from ralph.models.xapi.navigation.statements import PageViewed
@@ -18,7 +16,7 @@ class ServerEventToPageViewed(BaseXapiConverter):
     __src__ = Server
     __dest__ = PageViewed
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/converters/xapi/video.py
+++ b/src/ralph/models/edx/converters/xapi/video.py
@@ -1,7 +1,5 @@
 """Video event xAPI Converter."""
 
-from typing import Set
-
 from ralph.models.converter import ConversionItem
 from ralph.models.edx.video.statements import (
     UILoadVideo,
@@ -34,7 +32,7 @@ from .base import BaseXapiConverter
 class VideoBaseXapiConverter(BaseXapiConverter):
     """Base Video xAPI Converter."""
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -72,7 +70,7 @@ class UILoadVideoToVideoInitialized(VideoBaseXapiConverter):
     __src__ = UILoadVideo
     __dest__ = VideoInitialized
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -102,7 +100,7 @@ class UIPlayVideoToVideoPlayed(VideoBaseXapiConverter):
     __src__ = UIPlayVideo
     __dest__ = VideoPlayed
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -125,7 +123,7 @@ class UIPauseVideoToVideoPaused(VideoBaseXapiConverter):
     __src__ = UIPauseVideo
     __dest__ = VideoPaused
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -156,7 +154,7 @@ class UIStopVideoToVideoTerminated(VideoBaseXapiConverter):
     __src__ = UIStopVideo
     __dest__ = VideoTerminated
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(
@@ -195,7 +193,7 @@ class UISeekVideoToVideoSeeked(VideoBaseXapiConverter):
     __src__ = UISeekVideo
     __dest__ = VideoSeeked
 
-    def _get_conversion_items(self) -> Set[ConversionItem]:
+    def _get_conversion_items(self) -> set[ConversionItem]:
         """Return a set of ConversionItems used for conversion."""
         conversion_items = super()._get_conversion_items()
         return conversion_items.union(

--- a/src/ralph/models/edx/course_content_completion/statements.py
+++ b/src/ralph/models/edx/course_content_completion/statements.py
@@ -1,7 +1,6 @@
 """Course Content Completion event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -35,10 +34,7 @@ class UIEdxDoneToggled(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="edx.done.toggled")
 
-    event: Union[
-        Json[EdxDoneToggledEventField],
-        EdxDoneToggledEventField,
-    ]
+    event: Json[EdxDoneToggledEventField] | EdxDoneToggledEventField
     event_type: Literal["edx.done.toggled"]
     name: Literal["edx.done.toggled"]
 
@@ -59,9 +55,6 @@ class EdxDoneToggled(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.done.toggled")
 
-    event: Union[
-        Json[EdxDoneToggledEventField],
-        EdxDoneToggledEventField,
-    ]
+    event: Json[EdxDoneToggledEventField] | EdxDoneToggledEventField
     event_type: Literal["edx.done.toggled"]
     name: Literal["edx.done.toggled"]

--- a/src/ralph/models/edx/course_content_completion/statements.py
+++ b/src/ralph/models/edx/course_content_completion/statements.py
@@ -1,6 +1,6 @@
 """Course Content Completion event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -11,11 +11,6 @@ from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UIEdxDoneToggled(BaseBrowserModel):

--- a/src/ralph/models/edx/drag_and_drop/fields/events.py
+++ b/src/ralph/models/edx/drag_and_drop/fields/events.py
@@ -1,7 +1,5 @@
 """Video event fields definitions."""
 
-from typing import Optional
-
 from ...base import AbstractBaseEventField
 
 
@@ -18,7 +16,7 @@ class EdxDragAndDropV2FeedbackEventField(AbstractBaseEventField):
 
     content: str
     manually: bool
-    truncated: Optional[bool] = None
+    truncated: bool | None = None
 
 
 class EdxDragAndDropV2ItemDroppedEventField(AbstractBaseEventField):
@@ -44,12 +42,12 @@ class EdxDragAndDropV2ItemDroppedEventField(AbstractBaseEventField):
     """
 
     input: int
-    item: Optional[str] = None
+    item: str | None = None
     item_id: int
     is_correct: bool
     is_correct_location: bool
     location: str
-    location_id: Optional[int] = None
+    location_id: int | None = None
 
 
 class EdxDragAndDropV2ItemPickedUpEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/drag_and_drop/statements.py
+++ b/src/ralph/models/edx/drag_and_drop/statements.py
@@ -1,6 +1,6 @@
 """Drag and drop event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -12,11 +12,6 @@ from ralph.models.edx.drag_and_drop.fields.events import (
 from ralph.models.selector import selector
 
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxDragAndDropV2FeedbackClosed(BaseServerModel):

--- a/src/ralph/models/edx/drag_and_drop/statements.py
+++ b/src/ralph/models/edx/drag_and_drop/statements.py
@@ -1,7 +1,6 @@
 """Drag and drop event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -37,10 +36,7 @@ class EdxDragAndDropV2FeedbackClosed(BaseServerModel):
         event_source="server", event_type="edx.drag_and_drop_v2.feedback.closed"
     )
 
-    event: Union[
-        Json[EdxDragAndDropV2FeedbackEventField],
-        EdxDragAndDropV2FeedbackEventField,
-    ]
+    event: Json[EdxDragAndDropV2FeedbackEventField] | EdxDragAndDropV2FeedbackEventField
     event_type: Literal["edx.drag_and_drop_v2.feedback.closed"]
     name: Literal["edx.drag_and_drop_v2.feedback.closed"]
 
@@ -62,10 +58,7 @@ class EdxDragAndDropV2FeedbackOpened(BaseServerModel):
         event_source="server", event_type="edx.drag_and_drop_v2.feedback.opened"
     )
 
-    event: Union[
-        Json[EdxDragAndDropV2FeedbackEventField],
-        EdxDragAndDropV2FeedbackEventField,
-    ]
+    event: Json[EdxDragAndDropV2FeedbackEventField] | EdxDragAndDropV2FeedbackEventField
     event_type: Literal["edx.drag_and_drop_v2.feedback.opened"]
     name: Literal["edx.drag_and_drop_v2.feedback.opened"]
 
@@ -87,10 +80,10 @@ class EdxDragAndDropV2ItemDropped(BaseServerModel):
         event_source="server", event_type="edx.drag_and_drop_v2.item.dropped"
     )
 
-    event: Union[
-        Json[EdxDragAndDropV2ItemDroppedEventField],
-        EdxDragAndDropV2ItemDroppedEventField,
-    ]
+    event: (
+        Json[EdxDragAndDropV2ItemDroppedEventField]
+        | EdxDragAndDropV2ItemDroppedEventField
+    )
     event_type: Literal["edx.drag_and_drop_v2.item.dropped"]
     name: Literal["edx.drag_and_drop_v2.item.dropped"]
 
@@ -112,10 +105,10 @@ class EdxDragAndDropV2ItemPickedUp(BaseServerModel):
         event_source="server", event_type="edx.drag_and_drop_v2.item.picked_up"
     )
 
-    event: Union[
-        Json[EdxDragAndDropV2ItemPickedUpEventField],
-        EdxDragAndDropV2ItemPickedUpEventField,
-    ]
+    event: (
+        Json[EdxDragAndDropV2ItemPickedUpEventField]
+        | EdxDragAndDropV2ItemPickedUpEventField
+    )
     event_type: Literal["edx.drag_and_drop_v2.item.picked_up"]
     name: Literal["edx.drag_and_drop_v2.item.picked_up"]
 

--- a/src/ralph/models/edx/enrollment/fields/contexts.py
+++ b/src/ralph/models/edx/enrollment/fields/contexts.py
@@ -1,13 +1,8 @@
 """Enrollment event models context fields definitions."""
 
-import sys
+from typing import Literal
 
 from ...base import BaseContextField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxCourseEnrollmentUpgradeClickedContextField(BaseContextField):

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -28,4 +28,4 @@ class EnrollmentEventField(AbstractBaseEventField):
     mode: Union[
         Literal["audit"], Literal["honor"], Literal["professional"], Literal["verified"]
     ]
-    user_id: Union[int, Literal[""], None] = None
+    user_id: int | Literal[""] | None = None

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -1,14 +1,8 @@
 """Enrollment models event field definition."""
 
-import sys
-from typing import Union
+from typing import Literal, Union
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EnrollmentEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/enrollment/fields/events.py
+++ b/src/ralph/models/edx/enrollment/fields/events.py
@@ -1,6 +1,6 @@
 """Enrollment models event field definition."""
 
-from typing import Literal, Union
+from typing import Literal
 
 from ...base import AbstractBaseEventField
 
@@ -19,7 +19,5 @@ class EnrollmentEventField(AbstractBaseEventField):
     """
 
     course_id: str
-    mode: Union[
-        Literal["audit"], Literal["honor"], Literal["professional"], Literal["verified"]
-    ]
+    mode: Literal["audit", "honor", "professional", "verified"]
     user_id: int | Literal[""] | None = None

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -1,6 +1,6 @@
 """Enrollment event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -13,11 +13,6 @@ from .fields.contexts import (
     EdxCourseEnrollmentUpgradeSucceededContextField,
 )
 from .fields.events import EnrollmentEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxCourseEnrollmentActivated(BaseServerModel):

--- a/src/ralph/models/edx/enrollment/statements.py
+++ b/src/ralph/models/edx/enrollment/statements.py
@@ -1,7 +1,6 @@
 """Enrollment event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -35,10 +34,7 @@ class EdxCourseEnrollmentActivated(BaseServerModel):
     __selector__ = selector(
         event_source="server", event_type="edx.course.enrollment.activated"
     )
-    event: Union[
-        Json[EnrollmentEventField],
-        EnrollmentEventField,
-    ]
+    event: Json[EnrollmentEventField] | EnrollmentEventField
     event_type: Literal["edx.course.enrollment.activated"]
     name: Literal["edx.course.enrollment.activated"]
 
@@ -58,10 +54,7 @@ class EdxCourseEnrollmentDeactivated(BaseServerModel):
         event_source="server", event_type="edx.course.enrollment.deactivated"
     )
 
-    event: Union[
-        Json[EnrollmentEventField],
-        EnrollmentEventField,
-    ]
+    event: Json[EnrollmentEventField] | EnrollmentEventField
     event_type: Literal["edx.course.enrollment.deactivated"]
     name: Literal["edx.course.enrollment.deactivated"]
 
@@ -82,10 +75,7 @@ class EdxCourseEnrollmentModeChanged(BaseServerModel):
         event_source="server", event_type="edx.course.enrollment.mode_changed"
     )
 
-    event: Union[
-        EnrollmentEventField,
-        Json[EnrollmentEventField],
-    ]
+    event: EnrollmentEventField | Json[EnrollmentEventField]
     event_type: Literal["edx.course.enrollment.mode_changed"]
     name: Literal["edx.course.enrollment.mode_changed"]
 

--- a/src/ralph/models/edx/navigational/fields/events.py
+++ b/src/ralph/models/edx/navigational/fields/events.py
@@ -1,7 +1,8 @@
 """Navigational event field definition."""
 
+from typing import Annotated
+
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -1,6 +1,6 @@
 """Navigational event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json, field_validator
 
@@ -8,11 +8,6 @@ from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
 from .fields.events import NavigationalEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UIPageClose(BaseBrowserModel):

--- a/src/ralph/models/edx/navigational/statements.py
+++ b/src/ralph/models/edx/navigational/statements.py
@@ -1,7 +1,6 @@
 """Navigational event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json, field_validator
 
@@ -49,7 +48,7 @@ class UISeqGoto(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="seq_goto")
 
-    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event: Json[NavigationalEventField] | NavigationalEventField
     event_type: Literal["seq_goto"]
     name: Literal["seq_goto"]
 
@@ -68,15 +67,15 @@ class UISeqNext(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="seq_next")
 
-    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event: Json[NavigationalEventField] | NavigationalEventField
     event_type: Literal["seq_next"]
     name: Literal["seq_next"]
 
     @field_validator("event")
     @classmethod
     def validate_next_jump_event_field(
-        cls, value: Union[Json[NavigationalEventField], NavigationalEventField]
-    ) -> Union[Json[NavigationalEventField], NavigationalEventField]:
+        cls, value: Json[NavigationalEventField] | NavigationalEventField
+    ) -> Json[NavigationalEventField] | NavigationalEventField:
         """Check that event.new is equal to event.old + 1."""
         if value.new != value.old + 1:
             raise ValueError("event.new - event.old should be equal to 1")
@@ -99,15 +98,15 @@ class UISeqPrev(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="seq_prev")
 
-    event: Union[Json[NavigationalEventField], NavigationalEventField]
+    event: Json[NavigationalEventField] | NavigationalEventField
     event_type: Literal["seq_prev"]
     name: Literal["seq_prev"]
 
     @field_validator("event")
     @classmethod
     def validate_prev_jump_event_field(
-        cls, value: Union[Json[NavigationalEventField], NavigationalEventField]
-    ) -> Union[Json[NavigationalEventField], NavigationalEventField]:
+        cls, value: Json[NavigationalEventField] | NavigationalEventField
+    ) -> Json[NavigationalEventField] | NavigationalEventField:
         """Check that event.new is equal to event.old - 1."""
         if value.new != value.old - 1:
             raise ValueError("event.old - event.new should be equal to 1")

--- a/src/ralph/models/edx/notes/fields/events.py
+++ b/src/ralph/models/edx/notes/fields/events.py
@@ -1,16 +1,10 @@
 """Notes event field definition."""
 
-import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import StringConstraints
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class NotesEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/notes/fields/events.py
+++ b/src/ralph/models/edx/notes/fields/events.py
@@ -1,10 +1,9 @@
 """Notes event field definition."""
 
 import sys
-from typing import Dict, List
+from typing import Annotated
 
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 
@@ -32,8 +31,8 @@ class NotesEventField(AbstractBaseEventField):
     highlighted_content: str
     note_id: str
     note_text: Annotated[str, StringConstraints(max_length=8333)]
-    tags: List[str] = []
-    truncated: List[
+    tags: list[str] = []
+    truncated: list[
         Literal["note_text", "highlighted_content", "tags", "old_note_text", "old_tags"]
     ] = []
 
@@ -49,7 +48,7 @@ class UIEdxCourseStudentNotesEditedEventField(NotesEventField):
     """
 
     old_note_text: Annotated[str, StringConstraints(max_length=8333)]
-    old_tags: List[str] = []
+    old_tags: list[str] = []
 
 
 class UIEdxCourseStudentNotesNotesPageViewedEventField(AbstractBaseEventField):
@@ -100,4 +99,4 @@ class UIEdxCourseStudentNotesViewedEventField(AbstractBaseEventField):
             same text.
     """
 
-    notes: List[Dict[Literal["note_id"], str]]
+    notes: list[dict[Literal["note_id"], str]]

--- a/src/ralph/models/edx/notes/statements.py
+++ b/src/ralph/models/edx/notes/statements.py
@@ -1,6 +1,6 @@
 """Notes events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -15,11 +15,6 @@ from .fields.events import (
     UIEdxCourseStudentNotesUsedUnitLinkEventField,
     UIEdxCourseStudentNotesViewedEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UIEdxCourseStudentNotesAdded(BaseBrowserModel):

--- a/src/ralph/models/edx/notes/statements.py
+++ b/src/ralph/models/edx/notes/statements.py
@@ -1,7 +1,6 @@
 """Notes events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -38,10 +37,7 @@ class UIEdxCourseStudentNotesAdded(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.added"
     )
 
-    event: Union[
-        Json[NotesEventField],
-        NotesEventField,
-    ]
+    event: Json[NotesEventField] | NotesEventField
     event_type: Literal["edx.course.student_notes.added"]
     name: Literal["edx.course.student_notes.added"]
 
@@ -61,10 +57,7 @@ class UIEdxCourseStudentNotesDeleted(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.deleted"
     )
 
-    event: Union[
-        Json[NotesEventField],
-        NotesEventField,
-    ]
+    event: Json[NotesEventField] | NotesEventField
     event_type: Literal["edx.course.student_notes.deleted"]
     name: Literal["edx.course.student_notes.deleted"]
 
@@ -85,10 +78,10 @@ class UIEdxCourseStudentNotesEdited(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.edited"
     )
 
-    event: Union[
-        Json[UIEdxCourseStudentNotesEditedEventField],
-        UIEdxCourseStudentNotesEditedEventField,
-    ]
+    event: (
+        Json[UIEdxCourseStudentNotesEditedEventField]
+        | UIEdxCourseStudentNotesEditedEventField
+    )
     event_type: Literal["edx.course.student_notes.edited"]
     name: Literal["edx.course.student_notes.edited"]
 
@@ -111,10 +104,10 @@ class UIEdxCourseStudentNotesNotesPageViewed(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.notes_page_viewed"
     )
 
-    event: Union[
-        Json[UIEdxCourseStudentNotesNotesPageViewedEventField],
-        UIEdxCourseStudentNotesNotesPageViewedEventField,
-    ]
+    event: (
+        Json[UIEdxCourseStudentNotesNotesPageViewedEventField]
+        | UIEdxCourseStudentNotesNotesPageViewedEventField
+    )
     event_type: Literal["edx.course.student_notes.notes_page_viewed"]
     name: Literal["edx.course.student_notes.notes_page_viewed"]
 
@@ -135,10 +128,10 @@ class UIEdxCourseStudentNotesSearched(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.searched"
     )
 
-    event: Union[
-        Json[UIEdxCourseStudentNotesSearchedEventField],
-        UIEdxCourseStudentNotesSearchedEventField,
-    ]
+    event: (
+        Json[UIEdxCourseStudentNotesSearchedEventField]
+        | UIEdxCourseStudentNotesSearchedEventField
+    )
     event_type: Literal["edx.course.student_notes.searched"]
     name: Literal["edx.course.student_notes.searched"]
 
@@ -161,10 +154,10 @@ class UIEdxCourseStudentNotesUsedUnitLink(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.used_unit_link"
     )
 
-    event: Union[
-        Json[UIEdxCourseStudentNotesUsedUnitLinkEventField],
-        UIEdxCourseStudentNotesUsedUnitLinkEventField,
-    ]
+    event: (
+        Json[UIEdxCourseStudentNotesUsedUnitLinkEventField]
+        | UIEdxCourseStudentNotesUsedUnitLinkEventField
+    )
     event_type: Literal["edx.course.student_notes.used_unit_link"]
     name: Literal["edx.course.student_notes.used_unit_link"]
 
@@ -187,9 +180,9 @@ class UIEdxCourseStudentNotesViewed(BaseBrowserModel):
         event_source="browser", event_type="edx.course.student_notes.viewed"
     )
 
-    event: Union[
-        Json[UIEdxCourseStudentNotesViewedEventField],
-        UIEdxCourseStudentNotesViewedEventField,
-    ]
+    event: (
+        Json[UIEdxCourseStudentNotesViewedEventField]
+        | UIEdxCourseStudentNotesViewedEventField
+    )
     event_type: Literal["edx.course.student_notes.viewed"]
     name: Literal["edx.course.student_notes.viewed"]

--- a/src/ralph/models/edx/open_response_assessment/fields/events.py
+++ b/src/ralph/models/edx/open_response_assessment/fields/events.py
@@ -1,18 +1,12 @@
 """Open Response Assessment events model event fields definitions."""
 
-import sys
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import StringConstraints
 
 from ralph.models.edx.base import AbstractBaseEventField, BaseModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class ORAGetPeerSubmissionEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/open_response_assessment/fields/events.py
+++ b/src/ralph/models/edx/open_response_assessment/fields/events.py
@@ -2,11 +2,10 @@
 
 import sys
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ralph.models.edx.base import AbstractBaseEventField, BaseModelWithConfig
 
@@ -38,7 +37,7 @@ class ORAGetPeerSubmissionEventField(AbstractBaseEventField):
         ),
     ]
     requesting_student_id: str
-    submission_returned_uuid: Union[str, None] = None
+    submission_returned_uuid: str | None = None
 
 
 class ORAGetSubmissionForStaffGradingEventField(AbstractBaseEventField):
@@ -63,7 +62,7 @@ class ORAGetSubmissionForStaffGradingEventField(AbstractBaseEventField):
             pattern=(r"^block-v1:.+\+.+\+.+type@openassessment+block@[a-f0-9]{32}$")
         ),
     ]
-    submission_returned_uuid: Union[str, None] = None
+    submission_returned_uuid: str | None = None
     requesting_staff_id: str
     type: Literal["full-grade"]
 
@@ -93,7 +92,7 @@ class ORAAssessEventPartsField(BaseModelWithConfig):
 
     option: str
     criterion: ORAAssessEventPartsCriterionField
-    feedback: Optional[str] = None
+    feedback: str | None = None
 
 
 class ORAAssessEventRubricField(BaseModelWithConfig):
@@ -135,7 +134,7 @@ class ORAAssessEventField(AbstractBaseEventField):
     """
 
     feedback: str
-    parts: List[ORAAssessEventPartsField]
+    parts: list[ORAAssessEventPartsField]
     rubric: ORAAssessEventRubricField
     scored_at: datetime
     scorer_id: Annotated[str, StringConstraints(max_length=40)]
@@ -168,7 +167,7 @@ class ORASubmitFeedbackOnAssessmentsEventField(AbstractBaseEventField):
     """  # noqa: D205
 
     feedback_text: str
-    options: List[str]
+    options: list[str]
     submission_uuid: UUID
 
 
@@ -184,9 +183,9 @@ class ORACreateSubmissionEventAnswerField(BaseModelWithConfig):
             given for answer.
     """  # noqa: D205
 
-    parts: List[Dict[Literal["text"], str]]
-    file_keys: Optional[List[str]] = None
-    files_descriptions: Optional[List[str]] = None
+    parts: list[dict[Literal["text"], str]]
+    file_keys: list[str] | None = None
+    files_descriptions: list[str] | None = None
 
 
 class ORACreateSubmissionEventField(AbstractBaseEventField):
@@ -221,7 +220,7 @@ class ORASaveSubmissionEventSavedResponseField(BaseModelWithConfig):
     """
 
     text: str
-    file_upload_key: Optional[str] = None
+    file_upload_key: str | None = None
 
 
 class ORASaveSubmissionEventField(AbstractBaseEventField):
@@ -252,8 +251,8 @@ class ORAStudentTrainingAssessExampleEventField(AbstractBaseEventField):
         submission_uuid (str): Consists of the unique identifier of the response.
     """  # noqa: D205
 
-    corrections: Dict[str, str]
-    options_selected: Dict[str, str]
+    corrections: dict[str, str]
+    options_selected: dict[str, str]
     submission_uuid: UUID
 
 

--- a/src/ralph/models/edx/open_response_assessment/statements.py
+++ b/src/ralph/models/edx/open_response_assessment/statements.py
@@ -1,7 +1,6 @@
 """Open Response Assessment events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -241,6 +240,6 @@ class ORAUploadFile(BaseBrowserModel):
         event_source="browser", event_type="openassessment.upload_file"
     )
 
-    event: Union[Json[ORAUploadFileEventField], ORAUploadFileEventField]
+    event: Json[ORAUploadFileEventField] | ORAUploadFileEventField
     event_type: Literal["openassessment.upload_file"]
     name: Literal["openassessment.upload_file"]

--- a/src/ralph/models/edx/open_response_assessment/statements.py
+++ b/src/ralph/models/edx/open_response_assessment/statements.py
@@ -1,6 +1,6 @@
 """Open Response Assessment events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -19,11 +19,6 @@ from .fields.events import (
     ORASubmitFeedbackOnAssessmentsEventField,
     ORAUploadFileEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class ORAGetPeerSubmission(BaseServerModel):

--- a/src/ralph/models/edx/peer_instruction/fields/events.py
+++ b/src/ralph/models/edx/peer_instruction/fields/events.py
@@ -1,7 +1,8 @@
 """Peer instruction event field definition."""
 
+from typing import Annotated
+
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 

--- a/src/ralph/models/edx/peer_instruction/statements.py
+++ b/src/ralph/models/edx/peer_instruction/statements.py
@@ -1,7 +1,6 @@
 """Peer instruction events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -53,10 +52,7 @@ class PeerInstructionOriginalSubmitted(BaseServerModel):
         event_source="server", event_type="ubc.peer_instruction.original_submitted"
     )
 
-    event: Union[
-        Json[PeerInstructionEventField],
-        PeerInstructionEventField,
-    ]
+    event: Json[PeerInstructionEventField] | PeerInstructionEventField
     event_type: Literal["ubc.peer_instruction.original_submitted"]
     name: Literal["ubc.peer_instruction.original_submitted"]
 
@@ -79,9 +75,6 @@ class PeerInstructionRevisedSubmitted(BaseServerModel):
         event_source="server", event_type="ubc.peer_instruction.revised_submitted"
     )
 
-    event: Union[
-        Json[PeerInstructionEventField],
-        PeerInstructionEventField,
-    ]
+    event: Json[PeerInstructionEventField] | PeerInstructionEventField
     event_type: Literal["ubc.peer_instruction.revised_submitted"]
     name: Literal["ubc.peer_instruction.revised_submitted"]

--- a/src/ralph/models/edx/peer_instruction/statements.py
+++ b/src/ralph/models/edx/peer_instruction/statements.py
@@ -1,6 +1,6 @@
 """Peer instruction events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -8,11 +8,6 @@ from ralph.models.selector import selector
 
 from ..server import BaseServerModel
 from .fields.events import PeerInstructionEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class PeerInstructionAccessed(BaseServerModel):

--- a/src/ralph/models/edx/poll/statements.py
+++ b/src/ralph/models/edx/poll/statements.py
@@ -1,6 +1,6 @@
 """Poll event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -8,11 +8,6 @@ from ralph.models.edx.poll.fields.events import XBlockPollSubmittedEventField
 from ralph.models.selector import selector
 
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class XBlockPollSubmitted(BaseServerModel):

--- a/src/ralph/models/edx/poll/statements.py
+++ b/src/ralph/models/edx/poll/statements.py
@@ -1,7 +1,6 @@
 """Poll event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -29,10 +28,7 @@ class XBlockPollSubmitted(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="xblock.poll.submitted")
 
-    event: Union[
-        Json[XBlockPollSubmittedEventField],
-        XBlockPollSubmittedEventField,
-    ]
+    event: Json[XBlockPollSubmittedEventField] | XBlockPollSubmittedEventField
     event_type: Literal["xblock.poll.submitted"]
     name: Literal["xblock.poll.submitted"]
 

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -2,10 +2,9 @@
 
 import sys
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Annotated
 
 from pydantic import Field
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField, BaseModelWithConfig
 
@@ -42,13 +41,13 @@ class CorrectMap(BaseModelWithConfig):
         queuestate (json): see QueueStateField.
     """
 
-    answervariable: Optional[str] = None
+    answervariable: str | None = None
     correctness: Literal["correct", "incorrect"]
-    hint: Optional[str] = None
-    hintmode: Optional[Literal["on_request", "always"]] = None
+    hint: str | None = None
+    hintmode: Literal["on_request", "always"] | None = None
     msg: str
-    npoints: Optional[int] = None
-    queuestate: Optional[QueueState] = None
+    npoints: int | None = None
+    queuestate: QueueState | None = None
 
 
 class State(BaseModelWithConfig):
@@ -62,11 +61,11 @@ class State(BaseModelWithConfig):
         student_answers (dict): Consists of the answer(s) given by the user.
     """
 
-    correct_map: Dict[
+    correct_map: dict[
         Annotated[str, Field(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],
         CorrectMap,
     ]
-    done: Optional[bool] = None
+    done: bool | None = None
     input_state: dict
     seed: int
     student_answers: dict
@@ -87,7 +86,7 @@ class SubmissionAnswerField(BaseModelWithConfig):
             this user.
     """
 
-    answer: Union[str, List[str]]
+    answer: str | list[str]
     correct: bool
     input_type: str
     question: str
@@ -136,10 +135,10 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
             `student_answer` response. Consists either of `single` or `compound` value.
     """
 
-    choice_all: Optional[List[str]] = None
+    choice_all: list[str] | None = None
     correctness: bool
     hint_label: str
-    hints: List[dict]
+    hints: list[dict]
     module_id: str
     problem_part_id: str
     question_type: Literal[
@@ -149,7 +148,7 @@ class EdxProblemHintFeedbackDisplayedEventField(AbstractBaseEventField):
         "numericalresponse",
         "optionresponse",
     ]
-    student_answer: List[str]
+    student_answer: list[str]
     trigger_type: Literal["single", "compound"]
 
 
@@ -170,12 +169,12 @@ class ProblemCheckEventField(AbstractBaseEventField):
         success (str): Consists of either the `correct` or `incorrect` value.
     """
 
-    answers: Dict[
+    answers: dict[
         Annotated[str, Field(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],
-        Union[str, List[str]],
+        str | list[str],
     ]
     attempts: int
-    correct_map: Dict[
+    correct_map: dict[
         Annotated[str, Field(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],
         CorrectMap,
     ]
@@ -189,7 +188,7 @@ class ProblemCheckEventField(AbstractBaseEventField):
         ),
     ]
     state: State
-    submission: Dict[
+    submission: dict[
         Annotated[str, Field(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],
         SubmissionAnswerField,
     ]
@@ -207,9 +206,9 @@ class ProblemCheckFailEventField(AbstractBaseEventField):
         state (dict): Consists of the current problem state.
     """
 
-    answers: Dict[
+    answers: dict[
         Annotated[str, Field(pattern=r"^[a-f0-9]{32}_[0-9]_[0-9]$")],
-        Union[str, List[str]],
+        str | list[str],
     ]
     failure: Literal["closed", "unreset"]
     problem_id: Annotated[
@@ -281,7 +280,7 @@ class UIProblemResetEventField(AbstractBaseEventField):
             strings if multiple choices are allowed.
     """
 
-    answers: Union[str, List[str]]
+    answers: str | list[str]
 
 
 class UIProblemShowEventField(AbstractBaseEventField):
@@ -346,7 +345,7 @@ class SaveProblemFailEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: Dict[str, Union[int, str, list, dict]]
+    answers: dict[str, int | str | list | dict]
     failure: Literal["closed", "done"]
     problem_id: Annotated[
         str,
@@ -368,7 +367,7 @@ class SaveProblemSuccessEventField(AbstractBaseEventField):
         state (json): see StateField.
     """
 
-    answers: Dict[str, Union[int, str, list, dict]]
+    answers: dict[str, int | str | list | dict]
     problem_id: Annotated[
         str,
         Field(

--- a/src/ralph/models/edx/problem_interaction/fields/events.py
+++ b/src/ralph/models/edx/problem_interaction/fields/events.py
@@ -1,17 +1,11 @@
 """Problem interaction events model event fields definitions."""
 
-import sys
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 
 from ...base import AbstractBaseEventField, BaseModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class QueueState(BaseModelWithConfig):

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,7 +1,6 @@
 """Problem interaction events model definitions."""
 
 import sys
-from typing import List, Union
 
 from pydantic import Json
 
@@ -141,7 +140,7 @@ class UIProblemGraded(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="problem_graded")
 
-    event: List[Union[str, Literal[None], None]]
+    event: list[str | Literal[None] | None]
     event_type: Literal["problem_graded"]
     name: Literal["problem_graded"]
 
@@ -196,11 +195,7 @@ class UIProblemReset(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="problem_reset")
 
-    event: Union[
-        str,
-        Json[UIProblemResetEventField],
-        UIProblemResetEventField,
-    ]
+    event: str | Json[UIProblemResetEventField] | UIProblemResetEventField
     event_type: Literal["problem_reset"]
     name: Literal["problem_reset"]
 
@@ -237,10 +232,7 @@ class UIProblemShow(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="problem_show")
 
-    event: Union[
-        Json[UIProblemShowEventField],
-        UIProblemShowEventField,
-    ]
+    event: Json[UIProblemShowEventField] | UIProblemShowEventField
     event_type: Literal["problem_show"]
     name: Literal["problem_show"]
 

--- a/src/ralph/models/edx/problem_interaction/statements.py
+++ b/src/ralph/models/edx/problem_interaction/statements.py
@@ -1,6 +1,6 @@
 """Problem interaction events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -23,11 +23,6 @@ from .fields.events import (
     UIProblemResetEventField,
     UIProblemShowEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxProblemHintDemandhintDisplayed(BaseServerModel):

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -2,7 +2,6 @@
 
 import sys
 from pathlib import Path
-from typing import Union
 
 from pydantic import Json
 
@@ -62,4 +61,4 @@ class Server(BaseServerModel):
     )
 
     event_type: Path
-    event: Union[Json[ServerEventField], ServerEventField]
+    event: Json[ServerEventField] | ServerEventField

--- a/src/ralph/models/edx/server.py
+++ b/src/ralph/models/edx/server.py
@@ -1,18 +1,13 @@
 """Server event model definitions."""
 
-import sys
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Json
 
 from ralph.models.selector import LazyModelField, selector
 
 from .base import AbstractBaseEventField, BaseEdxModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class BaseServerModel(BaseEdxModel):

--- a/src/ralph/models/edx/survey/statements.py
+++ b/src/ralph/models/edx/survey/statements.py
@@ -1,7 +1,6 @@
 """Survey event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -29,10 +28,7 @@ class XBlockSurveySubmitted(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="xblock.survey.submitted")
 
-    event: Union[
-        Json[XBlockSurveySubmittedEventField],
-        XBlockSurveySubmittedEventField,
-    ]
+    event: Json[XBlockSurveySubmittedEventField] | XBlockSurveySubmittedEventField
     event_type: Literal["xblock.survey.submitted"]
     name: Literal["xblock.survey.submitted"]
 

--- a/src/ralph/models/edx/survey/statements.py
+++ b/src/ralph/models/edx/survey/statements.py
@@ -1,6 +1,6 @@
 """Survey event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -8,11 +8,6 @@ from ralph.models.edx.survey.fields.events import XBlockSurveySubmittedEventFiel
 from ralph.models.selector import selector
 
 from ..server import BaseServerModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class XBlockSurveySubmitted(BaseServerModel):

--- a/src/ralph/models/edx/teams_related/fields/events.py
+++ b/src/ralph/models/edx/teams_related/fields/events.py
@@ -1,10 +1,9 @@
 """Peer instruction event field definition."""
 
 import sys
-from typing import List, Union
+from typing import Annotated
 
 from pydantic import StringConstraints, validator
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 
@@ -41,7 +40,7 @@ class EdxTeamChangedEventField(TeamsEventField):
     field: str
     new: Annotated[str, StringConstraints(max_length=1250)]
     old: Annotated[str, StringConstraints(max_length=1250)]
-    truncated: List[str]
+    truncated: list[str]
 
     @validator("truncated")
     def check_truncated_length(cls, v):
@@ -103,7 +102,7 @@ class EdxTeamPageViewedEventField(TeamsEventField):
         "single-team",
         "single-topic",
     ]
-    topic_id: Union[str, Literal["null"]]
+    topic_id: str | Literal["null"]
 
 
 class EdxTeamSearchedEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/teams_related/fields/events.py
+++ b/src/ralph/models/edx/teams_related/fields/events.py
@@ -1,16 +1,10 @@
 """Peer instruction event field definition."""
 
-import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import StringConstraints, validator
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class TeamsEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/teams_related/statements.py
+++ b/src/ralph/models/edx/teams_related/statements.py
@@ -1,7 +1,6 @@
 """Teams-related events model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -37,10 +36,7 @@ class EdxTeamActivityUpdated(BaseServerModel):
         event_source="server", event_type="edx.team.activity_updated"
     )
 
-    event: Union[
-        Json[TeamsEventField],
-        TeamsEventField,
-    ]
+    event: Json[TeamsEventField] | TeamsEventField
     event_type: Literal["edx.team.activity_updated"]
     name: Literal["edx.team.activity_updated"]
 
@@ -58,10 +54,7 @@ class EdxTeamChanged(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.changed")
 
-    event: Union[
-        Json[EdxTeamChangedEventField],
-        EdxTeamChangedEventField,
-    ]
+    event: Json[EdxTeamChangedEventField] | EdxTeamChangedEventField
     event_type: Literal["edx.team.changed"]
     name: Literal["edx.team.changed"]
 
@@ -78,10 +71,7 @@ class EdxTeamCreated(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.created")
 
-    event: Union[
-        Json[TeamsEventField],
-        TeamsEventField,
-    ]
+    event: Json[TeamsEventField] | TeamsEventField
     event_type: Literal["edx.team.created"]
     name: Literal["edx.team.created"]
 
@@ -98,10 +88,7 @@ class EdxTeamDeleted(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.deleted")
 
-    event: Union[
-        Json[TeamsEventField],
-        TeamsEventField,
-    ]
+    event: Json[TeamsEventField] | TeamsEventField
     event_type: Literal["edx.team.deleted"]
     name: Literal["edx.team.deleted"]
 
@@ -118,10 +105,7 @@ class EdxTeamLearnerAdded(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.learner_added")
 
-    event: Union[
-        Json[EdxTeamLearnerAddedEventField],
-        EdxTeamLearnerAddedEventField,
-    ]
+    event: Json[EdxTeamLearnerAddedEventField] | EdxTeamLearnerAddedEventField
     event_type: Literal["edx.team.learner_added"]
     name: Literal["edx.team.learner_added"]
 
@@ -141,10 +125,7 @@ class EdxTeamLearnerRemoved(BaseServerModel):
         event_source="server", event_type="edx.team.learner_removed"
     )
 
-    event: Union[
-        Json[EdxTeamLearnerRemovedEventField],
-        EdxTeamLearnerRemovedEventField,
-    ]
+    event: Json[EdxTeamLearnerRemovedEventField] | EdxTeamLearnerRemovedEventField
     event_type: Literal["edx.team.learner_removed"]
     name: Literal["edx.team.learner_removed"]
 
@@ -162,10 +143,7 @@ class EdxTeamPageViewed(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.page_viewed")
 
-    event: Union[
-        Json[EdxTeamPageViewedEventField],
-        EdxTeamPageViewedEventField,
-    ]
+    event: Json[EdxTeamPageViewedEventField] | EdxTeamPageViewedEventField
     event_type: Literal["edx.team.page_viewed"]
     name: Literal["edx.team.page_viewed"]
 
@@ -183,9 +161,6 @@ class EdxTeamSearched(BaseServerModel):
 
     __selector__ = selector(event_source="server", event_type="edx.team.searched")
 
-    event: Union[
-        Json[EdxTeamSearchedEventField],
-        EdxTeamSearchedEventField,
-    ]
+    event: Json[EdxTeamSearchedEventField] | EdxTeamSearchedEventField
     event_type: Literal["edx.team.searched"]
     name: Literal["edx.team.searched"]

--- a/src/ralph/models/edx/teams_related/statements.py
+++ b/src/ralph/models/edx/teams_related/statements.py
@@ -1,6 +1,6 @@
 """Teams-related events model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -15,11 +15,6 @@ from .fields.events import (
     EdxTeamSearchedEventField,
     TeamsEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class EdxTeamActivityUpdated(BaseServerModel):

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,6 +1,6 @@
 """Textbook interaction event fields definitions."""
 
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 from pydantic import Field, StringConstraints
 
@@ -108,21 +108,7 @@ class TextbookPdfZoomMenuChangedEventField(TextbookInteractionBaseEventField):
     """
 
     name: Literal["textbook.pdf.zoom.menu.changed"]
-    amount: Union[
-        Literal["0.5"],
-        Literal["0.75"],
-        Literal["1"],
-        Literal["1.25"],
-        Literal["1.5"],
-        Literal["2"],
-        Literal["3"],
-        Literal["4"],
-        Literal["auto"],
-        Literal["custom"],
-        Literal["page-actual"],
-        Literal["page-fit"],
-        Literal["page-width"],
-    ]
+    amount: Literal["0.5", "0.75", "1", "1.25", "1.5", "2", "3", "4", "auto", "custom", "page-actual", "page-fit", "page-width"]
 
 
 class TextbookPdfDisplayScaledEventField(TextbookInteractionBaseEventField):

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,16 +1,10 @@
 """Textbook interaction event fields definitions."""
 
-import sys
-from typing import Annotated, Union
+from typing import Annotated, Literal, Union
 
 from pydantic import Field, StringConstraints
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class TextbookInteractionBaseEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -1,10 +1,9 @@
 """Textbook interaction event fields definitions."""
 
 import sys
-from typing import Optional, Union
+from typing import Annotated, Union
 
 from pydantic import Field, StringConstraints
-from typing_extensions import Annotated
 
 from ...base import AbstractBaseEventField
 
@@ -271,7 +270,7 @@ class BookEventField(AbstractBaseEventField):
     ]
     name: Literal["textbook.pdf.page.loaded", "textbook.pdf.page.navigatednext"]
     new: int
-    old: Optional[int] = None
+    old: int | None = None
     type: Annotated[
         Literal["gotopage", "prevpage", "nextpage"],
         Field(alias="type"),

--- a/src/ralph/models/edx/textbook_interaction/fields/events.py
+++ b/src/ralph/models/edx/textbook_interaction/fields/events.py
@@ -108,7 +108,21 @@ class TextbookPdfZoomMenuChangedEventField(TextbookInteractionBaseEventField):
     """
 
     name: Literal["textbook.pdf.zoom.menu.changed"]
-    amount: Literal["0.5", "0.75", "1", "1.25", "1.5", "2", "3", "4", "auto", "custom", "page-actual", "page-fit", "page-width"]
+    amount: Literal[
+        "0.5",
+        "0.75",
+        "1",
+        "1.25",
+        "1.5",
+        "2",
+        "3",
+        "4",
+        "auto",
+        "custom",
+        "page-actual",
+        "page-fit",
+        "page-width",
+    ]
 
 
 class TextbookPdfDisplayScaledEventField(TextbookInteractionBaseEventField):

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -1,7 +1,6 @@
 """Textbook interaction event model definitions."""
 
 import sys
-from typing import Union
 
 from pydantic import Json
 
@@ -45,7 +44,7 @@ class UIBook(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="book")
 
-    event: Union[Json[BookEventField], BookEventField]
+    event: Json[BookEventField] | BookEventField
     event_type: Literal["book"]
     name: Literal["book"]
 
@@ -66,10 +65,10 @@ class UITextbookPdfThumbnailsToggled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.thumbnails.toggled"
     )
 
-    event: Union[
-        Json[TextbookPdfThumbnailsToggledEventField],
-        TextbookPdfThumbnailsToggledEventField,
-    ]
+    event: (
+        Json[TextbookPdfThumbnailsToggledEventField]
+        | TextbookPdfThumbnailsToggledEventField
+    )
     event_type: Literal["textbook.pdf.thumbnails.toggled"]
     name: Literal["textbook.pdf.thumbnails.toggled"]
 
@@ -90,10 +89,10 @@ class UITextbookPdfThumbnailNavigated(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.thumbnail.navigated"
     )
 
-    event: Union[
-        Json[TextbookPdfThumbnailNavigatedEventField],
-        TextbookPdfThumbnailNavigatedEventField,
-    ]
+    event: (
+        Json[TextbookPdfThumbnailNavigatedEventField]
+        | TextbookPdfThumbnailNavigatedEventField
+    )
     event_type: Literal["textbook.pdf.thumbnail.navigated"]
     name: Literal["textbook.pdf.thumbnail.navigated"]
 
@@ -114,10 +113,9 @@ class UITextbookPdfOutlineToggled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.outline.toggled"
     )
 
-    event: Union[
-        Json[TextbookPdfOutlineToggledEventField],
-        TextbookPdfOutlineToggledEventField,
-    ]
+    event: (
+        Json[TextbookPdfOutlineToggledEventField] | TextbookPdfOutlineToggledEventField
+    )
     event_type: Literal["textbook.pdf.outline.toggled"]
     name: Literal["textbook.pdf.outline.toggled"]
 
@@ -138,10 +136,10 @@ class UITextbookPdfChapterNavigated(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.chapter.navigated"
     )
 
-    event: Union[
-        Json[TextbookPdfChapterNavigatedEventField],
-        TextbookPdfChapterNavigatedEventField,
-    ]
+    event: (
+        Json[TextbookPdfChapterNavigatedEventField]
+        | TextbookPdfChapterNavigatedEventField
+    )
     event_type: Literal["textbook.pdf.chapter.navigated"]
     name: Literal["textbook.pdf.chapter.navigated"]
 
@@ -161,10 +159,7 @@ class UITextbookPdfPageNavigated(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.page.navigated"
     )
 
-    event: Union[
-        Json[TextbookPdfPageNavigatedEventField],
-        TextbookPdfPageNavigatedEventField,
-    ]
+    event: Json[TextbookPdfPageNavigatedEventField] | TextbookPdfPageNavigatedEventField
     event_type: Literal["textbook.pdf.page.navigated"]
     name: Literal["textbook.pdf.page.navigated"]
 
@@ -185,10 +180,10 @@ class UITextbookPdfZoomButtonsChanged(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.zoom.buttons.changed"
     )
 
-    event: Union[
-        Json[TextbookPdfZoomButtonsChangedEventField],
-        TextbookPdfZoomButtonsChangedEventField,
-    ]
+    event: (
+        Json[TextbookPdfZoomButtonsChangedEventField]
+        | TextbookPdfZoomButtonsChangedEventField
+    )
     event_type: Literal["textbook.pdf.zoom.buttons.changed"]
     name: Literal["textbook.pdf.zoom.buttons.changed"]
 
@@ -208,10 +203,10 @@ class UITextbookPdfZoomMenuChanged(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.zoom.menu.changed"
     )
 
-    event: Union[
-        Json[TextbookPdfZoomMenuChangedEventField],
-        TextbookPdfZoomMenuChangedEventField,
-    ]
+    event: (
+        Json[TextbookPdfZoomMenuChangedEventField]
+        | TextbookPdfZoomMenuChangedEventField
+    )
     event_type: Literal["textbook.pdf.zoom.menu.changed"]
     name: Literal["textbook.pdf.zoom.menu.changed"]
 
@@ -232,10 +227,7 @@ class UITextbookPdfDisplayScaled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.display.scaled"
     )
 
-    event: Union[
-        Json[TextbookPdfDisplayScaledEventField],
-        TextbookPdfDisplayScaledEventField,
-    ]
+    event: Json[TextbookPdfDisplayScaledEventField] | TextbookPdfDisplayScaledEventField
     event_type: Literal["textbook.pdf.display.scaled"]
     name: Literal["textbook.pdf.display.scaled"]
 
@@ -256,10 +248,7 @@ class UITextbookPdfPageScrolled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.page.scrolled"
     )
 
-    event: Union[
-        Json[TextbookPdfPageScrolledEventField],
-        TextbookPdfPageScrolledEventField,
-    ]
+    event: Json[TextbookPdfPageScrolledEventField] | TextbookPdfPageScrolledEventField
     event_type: Literal["textbook.pdf.page.scrolled"]
     name: Literal["textbook.pdf.page.scrolled"]
 
@@ -279,10 +268,9 @@ class UITextbookPdfSearchExecuted(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.search.executed"
     )
 
-    event: Union[
-        Json[TextbookPdfSearchExecutedEventField],
-        TextbookPdfSearchExecutedEventField,
-    ]
+    event: (
+        Json[TextbookPdfSearchExecutedEventField] | TextbookPdfSearchExecutedEventField
+    )
     event_type: Literal["textbook.pdf.search.executed"]
     name: Literal["textbook.pdf.search.executed"]
 
@@ -303,10 +291,10 @@ class UITextbookPdfSearchNavigatedNext(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.search.navigatednext"
     )
 
-    event: Union[
-        Json[TextbookPdfSearchNavigatedNextEventField],
-        TextbookPdfSearchNavigatedNextEventField,
-    ]
+    event: (
+        Json[TextbookPdfSearchNavigatedNextEventField]
+        | TextbookPdfSearchNavigatedNextEventField
+    )
     event_type: Literal["textbook.pdf.search.navigatednext"]
     name: Literal["textbook.pdf.search.navigatednext"]
 
@@ -327,10 +315,10 @@ class UITextbookPdfSearchHighlightToggled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.search.highlight.toggled"
     )
 
-    event: Union[
-        Json[TextbookPdfSearchHighlightToggledEventField],
-        TextbookPdfSearchHighlightToggledEventField,
-    ]
+    event: (
+        Json[TextbookPdfSearchHighlightToggledEventField]
+        | TextbookPdfSearchHighlightToggledEventField
+    )
     event_type: Literal["textbook.pdf.search.highlight.toggled"]
     name: Literal["textbook.pdf.search.highlight.toggled"]
 
@@ -352,9 +340,9 @@ class UITextbookPdfSearchCaseSensitivityToggled(BaseBrowserModel):
         event_source="browser", event_type="textbook.pdf.searchcasesensitivity.toggled"
     )
 
-    event: Union[
-        Json[TextbookPdfSearchCaseSensitivityToggledEventField],
-        TextbookPdfSearchCaseSensitivityToggledEventField,
-    ]
+    event: (
+        Json[TextbookPdfSearchCaseSensitivityToggledEventField]
+        | TextbookPdfSearchCaseSensitivityToggledEventField
+    )
     event_type: Literal["textbook.pdf.searchcasesensitivity.toggled"]
     name: Literal["textbook.pdf.searchcasesensitivity.toggled"]

--- a/src/ralph/models/edx/textbook_interaction/statements.py
+++ b/src/ralph/models/edx/textbook_interaction/statements.py
@@ -1,6 +1,6 @@
 """Textbook interaction event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -23,11 +23,6 @@ from .fields.events import (
     TextbookPdfZoomButtonsChangedEventField,
     TextbookPdfZoomMenuChangedEventField,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UIBook(BaseBrowserModel):

--- a/src/ralph/models/edx/video/fields/events.py
+++ b/src/ralph/models/edx/video/fields/events.py
@@ -1,15 +1,10 @@
 """Video event fields definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import ConfigDict, NonNegativeFloat
 
 from ...base import AbstractBaseEventField
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class VideoBaseEventField(AbstractBaseEventField):

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -1,6 +1,6 @@
 """Video event model definitions."""
 
-import sys
+from typing import Literal
 
 from pydantic import Json
 
@@ -17,11 +17,6 @@ from ralph.models.edx.video.fields.events import (
 from ralph.models.selector import selector
 
 from ..browser import BaseBrowserModel
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class UILoadVideo(BaseBrowserModel):

--- a/src/ralph/models/edx/video/statements.py
+++ b/src/ralph/models/edx/video/statements.py
@@ -1,7 +1,6 @@
 """Video event model definitions."""
 
 import sys
-from typing import Optional, Union
 
 from pydantic import Json
 
@@ -39,10 +38,7 @@ class UILoadVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="load_video")
 
-    event: Union[
-        Json[VideoBaseEventField],
-        VideoBaseEventField,
-    ]
+    event: Json[VideoBaseEventField] | VideoBaseEventField
     event_type: Literal["load_video"]
     name: Literal["load_video", "edx.video.loaded"]
 
@@ -61,12 +57,9 @@ class UIPlayVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="play_video")
 
-    event: Union[
-        Json[PlayVideoEventField],
-        PlayVideoEventField,
-    ]
+    event: Json[PlayVideoEventField] | PlayVideoEventField
     event_type: Literal["play_video"]
-    name: Optional[Literal["play_video", "edx.video.played"]] = None
+    name: Literal["play_video", "edx.video.played"] | None = None
 
 
 class UIPauseVideo(BaseBrowserModel):
@@ -83,12 +76,9 @@ class UIPauseVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="pause_video")
 
-    event: Union[
-        Json[PauseVideoEventField],
-        PauseVideoEventField,
-    ]
+    event: Json[PauseVideoEventField] | PauseVideoEventField
     event_type: Literal["pause_video"]
-    name: Optional[Literal["pause_video", "edx.video.paused"]] = None
+    name: Literal["pause_video", "edx.video.paused"] | None = None
 
 
 class UISeekVideo(BaseBrowserModel):
@@ -106,12 +96,9 @@ class UISeekVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="seek_video")
 
-    event: Union[
-        Json[SeekVideoEventField],
-        SeekVideoEventField,
-    ]
+    event: Json[SeekVideoEventField] | SeekVideoEventField
     event_type: Literal["seek_video"]
-    name: Optional[Literal["seek_video", "edx.video.position.changed"]] = None
+    name: Literal["seek_video", "edx.video.position.changed"] | None = None
 
 
 class UIStopVideo(BaseBrowserModel):
@@ -128,12 +115,9 @@ class UIStopVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="stop_video")
 
-    event: Union[
-        Json[StopVideoEventField],
-        StopVideoEventField,
-    ]
+    event: Json[StopVideoEventField] | StopVideoEventField
     event_type: Literal["stop_video"]
-    name: Optional[Literal["stop_video", "edx.video.stopped"]] = None
+    name: Literal["stop_video", "edx.video.stopped"] | None = None
 
 
 class UIHideTranscript(BaseBrowserModel):
@@ -151,10 +135,7 @@ class UIHideTranscript(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="hide_transcript")
 
-    event: Union[
-        Json[VideoHideTranscriptEventField],
-        VideoHideTranscriptEventField,
-    ]
+    event: Json[VideoHideTranscriptEventField] | VideoHideTranscriptEventField
     event_type: Literal["hide_transcript"]
     name: Literal["hide_transcript", "edx.video.transcript.hidden"]
 
@@ -174,10 +155,7 @@ class UIShowTranscript(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="show_transcript")
 
-    event: Union[
-        Json[VideoShowTranscriptEventField],
-        VideoShowTranscriptEventField,
-    ]
+    event: Json[VideoShowTranscriptEventField] | VideoShowTranscriptEventField
     event_type: Literal["show_transcript"]
     name: Literal["show_transcript", "edx.video.transcript.shown"]
 
@@ -195,12 +173,9 @@ class UISpeedChangeVideo(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="speed_change_video")
 
-    event: Union[
-        Json[SpeedChangeVideoEventField],
-        SpeedChangeVideoEventField,
-    ]
+    event: Json[SpeedChangeVideoEventField] | SpeedChangeVideoEventField
     event_type: Literal["speed_change_video"]
-    name: Optional[Literal["speed_change_video"]] = None
+    name: Literal["speed_change_video"] | None = None
 
 
 class UIVideoHideCCMenu(BaseBrowserModel):
@@ -216,12 +191,9 @@ class UIVideoHideCCMenu(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="video_hide_cc_menu")
 
-    event: Union[
-        Json[VideoBaseEventField],
-        VideoBaseEventField,
-    ]
+    event: Json[VideoBaseEventField] | VideoBaseEventField
     event_type: Literal["video_hide_cc_menu"]
-    name: Optional[Literal["video_hide_cc_menu"]] = None
+    name: Literal["video_hide_cc_menu"] | None = None
 
 
 class UIVideoShowCCMenu(BaseBrowserModel):
@@ -239,9 +211,6 @@ class UIVideoShowCCMenu(BaseBrowserModel):
 
     __selector__ = selector(event_source="browser", event_type="video_show_cc_menu")
 
-    event: Union[
-        Json[VideoBaseEventField],
-        VideoBaseEventField,
-    ]
+    event: Json[VideoBaseEventField] | VideoBaseEventField
     event_type: Literal["video_show_cc_menu"]
-    name: Optional[Literal["video_show_cc_menu"]] = None
+    name: Literal["video_show_cc_menu"] | None = None

--- a/src/ralph/models/selector.py
+++ b/src/ralph/models/selector.py
@@ -1,12 +1,13 @@
 """Model selector definition."""
 
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib import import_module
 from inspect import getmembers, isclass
 from itertools import chain
 from types import ModuleType
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -19,7 +20,7 @@ from ralph.utils import get_dict_value_from_path
 class LazyModelField:
     """Model field."""
 
-    path: Tuple[str]
+    path: tuple[str]
 
     def __init__(self, path: str) -> None:
         """Initialize Lazy Model Field."""
@@ -31,9 +32,9 @@ class Rule:
     """Rule used for selection."""
 
     field: LazyModelField
-    value: Union[LazyModelField, Any]
+    value: LazyModelField | Any
 
-    def check(self, event: Dict) -> bool:
+    def check(self, event: Mapping) -> bool:
         """Check if event matches the rule.
 
         Args:
@@ -46,7 +47,7 @@ class Rule:
         return event_value == expected_value
 
 
-def selector(**filters: Any) -> List[Rule]:
+def selector(**filters: Any) -> list[Rule]:
     """Return a list of rules that should match in order to select an event.
 
     Args:
@@ -72,7 +73,7 @@ class ModelSelector:
         self.decision_tree = self.get_decision_tree(self.model_rules)
 
     @staticmethod
-    def build_model_rules(module: ModuleType) -> Dict:
+    def build_model_rules(module: ModuleType) -> dict:
         """Build the model_rules dictionary.
 
         Using BaseModel classes defined in the module.
@@ -83,11 +84,11 @@ class ModelSelector:
                 model_rules[class_] = class_.__selector__
         return model_rules
 
-    def get_first_model(self, event: Dict) -> Any:
+    def get_first_model(self, event: Mapping) -> Any:
         """Return the first matching model for the event. See `self.get_models`."""
         return self.get_models(event)[0]
 
-    def get_models(self, event: dict, tree=None):
+    def get_models(self, event: Mapping, tree=None):
         """Recursively go through the decision tree to find the event matching models.
 
         Args:

--- a/src/ralph/models/validator.py
+++ b/src/ralph/models/validator.py
@@ -2,7 +2,8 @@
 
 import json
 import logging
-from typing import Any, Generator, Optional, TextIO
+from collections.abc import Generator, Mapping
+from typing import Any, TextIO
 
 from pydantic import ValidationError
 
@@ -46,14 +47,14 @@ class Validator:
                     raise BadFormatException(message) from err
         logger.info("Total events: %d, Invalid events: %d", total, total - success)
 
-    def get_first_valid_model(self, event: dict) -> Any:
+    def get_first_valid_model(self, event: Mapping) -> Any:
         """Return the first successfully instantiated model for the event.
 
         Raises:
             UnknownEventException: When the event does not match any model.
             ValidationError: When the last validated event is invalid.
         """
-        error: Optional[BaseException] = None
+        error: BaseException | None = None
         for model in self.model_selector.get_models(event):
             try:
                 return model(**event)
@@ -78,7 +79,7 @@ class Validator:
 
     @staticmethod
     def _log_error(
-        message: object, event_str: str, error: Optional[BaseException] = None
+        message: object, event_str: str, error: BaseException | None = None
     ) -> None:
         logger.error(message)
         logger.debug("Raised error: %s, for event : %s", error, event_str)

--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -1,7 +1,7 @@
 """Base xAPI `Agent` definitions."""
 
 from abc import ABC
-from typing import Literal, Union
+from typing import Literal
 
 from ralph.conf import NonEmptyStrictStr
 from ralph.models.xapi.config import BaseModelWithConfig
@@ -71,9 +71,9 @@ class BaseXapiAgentWithAccount(BaseXapiAgentCommonProperties, BaseXapiAccountIFI
     """
 
 
-BaseXapiAgent = Union[
-    BaseXapiAgentWithMbox,
-    BaseXapiAgentWithMboxSha1Sum,
-    BaseXapiAgentWithOpenId,
-    BaseXapiAgentWithAccount,
-]
+BaseXapiAgent = (
+    BaseXapiAgentWithMbox
+    | BaseXapiAgentWithMboxSha1Sum
+    | BaseXapiAgentWithOpenId
+    | BaseXapiAgentWithAccount
+)

--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -1,8 +1,7 @@
 """Base xAPI `Agent` definitions."""
 
-import sys
 from abc import ABC
-from typing import Union
+from typing import Literal, Union
 
 from ralph.conf import NonEmptyStrictStr
 from ralph.models.xapi.config import BaseModelWithConfig
@@ -14,11 +13,6 @@ from .ifi import (
     BaseXapiMboxSha1SumIFI,
     BaseXapiOpenIdIFI,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class BaseXapiAgentAccount(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/agents.py
+++ b/src/ralph/models/xapi/base/agents.py
@@ -2,7 +2,7 @@
 
 import sys
 from abc import ABC
-from typing import Optional, Union
+from typing import Union
 
 from ralph.conf import NonEmptyStrictStr
 from ralph.models.xapi.config import BaseModelWithConfig
@@ -44,7 +44,7 @@ class BaseXapiAgentCommonProperties(BaseModelWithConfig, ABC):
     """
 
     objectType: Literal["Agent"] = "Agent"
-    name: Optional[NonEmptyStrictStr] = None
+    name: NonEmptyStrictStr | None = None
 
 
 class BaseXapiAgentWithMbox(BaseXapiAgentCommonProperties, BaseXapiMboxIFI):

--- a/src/ralph/models/xapi/base/attachments.py
+++ b/src/ralph/models/xapi/base/attachments.py
@@ -1,7 +1,5 @@
 """Base xAPI `Attachments` definitions."""
 
-from typing import Optional
-
 from pydantic import AnyUrl
 
 from ..config import BaseModelWithConfig
@@ -23,8 +21,8 @@ class BaseXapiAttachment(BaseModelWithConfig):
 
     usageType: IRI
     display: LanguageMap
-    description: Optional[LanguageMap] = None
+    description: LanguageMap | None = None
     contentType: str
     length: int
     sha2: str
-    fileUrl: Optional[AnyUrl] = None
+    fileUrl: AnyUrl | None = None

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -1,6 +1,6 @@
 """Common for xAPI base definitions."""
 
-from typing import Dict, Type, Union
+from typing import Type, Union
 
 from langcodes import tag_is_valid
 from pydantic import RootModel, model_validator, validate_email
@@ -9,7 +9,7 @@ from rfc3987 import parse
 from ralph.conf import NonEmptyStrictStr
 
 
-class ResourceIdentifier(RootModel[Union[str]]):
+class ResourceIdentifier(RootModel[str]):
     """Pydantic custom data type for Resource Identifiers."""
 
     def __hash__(self):  # noqa: D105
@@ -59,7 +59,7 @@ class LanguageTag(RootModel[Union[str, "LanguageTag"]]):
         return str(tag)
 
 
-LanguageMap = Dict[LanguageTag, NonEmptyStrictStr]
+LanguageMap = dict[LanguageTag, NonEmptyStrictStr]
 
 
 class MailtoEmail(RootModel[str]):

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -1,6 +1,6 @@
 """Common for xAPI base definitions."""
 
-from typing import Type, Union
+from typing import Type
 
 from langcodes import tag_is_valid
 from pydantic import RootModel, model_validator, validate_email
@@ -41,7 +41,7 @@ class URI(ResourceIdentifier):
         return str(uri)
 
 
-class LanguageTag(RootModel[Union[str, "LanguageTag"]]):
+class LanguageTag(RootModel[str | "LanguageTag"]):
     """Pydantic custom data type validating RFC 5646 Language tags."""
 
     def __hash__(self):  # noqa: D105

--- a/src/ralph/models/xapi/base/common.py
+++ b/src/ralph/models/xapi/base/common.py
@@ -1,6 +1,6 @@
 """Common for xAPI base definitions."""
 
-from typing import Type
+from typing import Type, Union
 
 from langcodes import tag_is_valid
 from pydantic import RootModel, model_validator, validate_email
@@ -41,7 +41,7 @@ class URI(ResourceIdentifier):
         return str(uri)
 
 
-class LanguageTag(RootModel[str | "LanguageTag"]):
+class LanguageTag(RootModel[Union[str, "LanguageTag"]]):
     """Pydantic custom data type validating RFC 5646 Language tags."""
 
     def __hash__(self):  # noqa: D105

--- a/src/ralph/models/xapi/base/contexts.py
+++ b/src/ralph/models/xapi/base/contexts.py
@@ -1,6 +1,5 @@
 """Base xAPI `Context` definitions."""
 
-from typing import Dict, List, Optional, Union
 from uuid import UUID
 
 from ralph.conf import NonEmptyStrictStr
@@ -25,10 +24,10 @@ class BaseXapiContextContextActivities(BaseModelWithConfig):
             properties.
     """
 
-    parent: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
-    grouping: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
-    category: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
-    other: Optional[Union[BaseXapiActivity, List[BaseXapiActivity]]] = None
+    parent: BaseXapiActivity | list[BaseXapiActivity] | None = None
+    grouping: BaseXapiActivity | list[BaseXapiActivity] | None = None
+    category: BaseXapiActivity | list[BaseXapiActivity] | None = None
+    other: BaseXapiActivity | list[BaseXapiActivity] | None = None
 
 
 class BaseXapiContext(BaseModelWithConfig):
@@ -46,12 +45,12 @@ class BaseXapiContext(BaseModelWithConfig):
         extensions (dict): Consists of a dictionary of other properties as needed.
     """
 
-    registration: Optional[UUID] = None
-    instructor: Optional[BaseXapiAgent] = None
-    team: Optional[BaseXapiGroup] = None
-    contextActivities: Optional[BaseXapiContextContextActivities] = None
-    revision: Optional[NonEmptyStrictStr] = None
-    platform: Optional[NonEmptyStrictStr] = None
-    language: Optional[LanguageTag] = None
-    statement: Optional[BaseXapiStatementRef] = None
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None
+    registration: UUID | None = None
+    instructor: BaseXapiAgent | None = None
+    team: BaseXapiGroup | None = None
+    contextActivities: BaseXapiContextContextActivities | None = None
+    revision: NonEmptyStrictStr | None = None
+    platform: NonEmptyStrictStr | None = None
+    language: LanguageTag | None = None
+    statement: BaseXapiStatementRef | None = None
+    extensions: dict[IRI, str | int | bool | list | dict | None] | None = None

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -1,7 +1,7 @@
 """Base xAPI `Group` definitions."""
 
 from abc import ABC
-from typing import Literal, Union
+from typing import Literal
 
 from ralph.conf import NonEmptyStrictStr
 
@@ -83,10 +83,10 @@ class BaseXapiIdentifiedGroupWithAccount(BaseXapiIdentifiedGroup, BaseXapiAccoun
     """
 
 
-BaseXapiGroup = Union[
-    BaseXapiAnonymousGroup,
-    BaseXapiIdentifiedGroupWithMbox,
-    BaseXapiIdentifiedGroupWithMboxSha1Sum,
-    BaseXapiIdentifiedGroupWithOpenId,
-    BaseXapiIdentifiedGroupWithAccount,
-]
+BaseXapiGroup = (
+    BaseXapiAnonymousGroup
+    | BaseXapiIdentifiedGroupWithMbox
+    | BaseXapiIdentifiedGroupWithMboxSha1Sum
+    | BaseXapiIdentifiedGroupWithOpenId
+    | BaseXapiIdentifiedGroupWithAccount
+)

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -2,7 +2,7 @@
 
 import sys
 from abc import ABC
-from typing import List, Optional, Union
+from typing import Union
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -32,7 +32,7 @@ class BaseXapiGroupCommonProperties(BaseModelWithConfig, ABC):
     """
 
     objectType: Literal["Group"]
-    name: Optional[NonEmptyStrictStr] = None
+    name: NonEmptyStrictStr | None = None
 
 
 class BaseXapiAnonymousGroup(BaseXapiGroupCommonProperties):
@@ -44,7 +44,7 @@ class BaseXapiAnonymousGroup(BaseXapiGroupCommonProperties):
         member (list): Consist of a list of the members of this Group.
     """
 
-    member: List[BaseXapiAgent]
+    member: list[BaseXapiAgent]
 
 
 class BaseXapiIdentifiedGroup(BaseXapiGroupCommonProperties):
@@ -56,7 +56,7 @@ class BaseXapiIdentifiedGroup(BaseXapiGroupCommonProperties):
         member (list): Consist of a list of the members of this Group.
     """
 
-    member: Optional[List[BaseXapiAgent]] = None
+    member: list[BaseXapiAgent] | None = None
 
 
 class BaseXapiIdentifiedGroupWithMbox(BaseXapiIdentifiedGroup, BaseXapiMboxIFI):

--- a/src/ralph/models/xapi/base/groups.py
+++ b/src/ralph/models/xapi/base/groups.py
@@ -1,8 +1,9 @@
 """Base xAPI `Group` definitions."""
 
-import sys
 from abc import ABC
-from typing import Union
+from typing import Literal, Union
+
+from ralph.conf import NonEmptyStrictStr
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -12,13 +13,6 @@ from .ifi import (
     BaseXapiMboxSha1SumIFI,
     BaseXapiOpenIdIFI,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-from ralph.conf import NonEmptyStrictStr
 
 
 class BaseXapiGroupCommonProperties(BaseModelWithConfig, ABC):

--- a/src/ralph/models/xapi/base/ifi.py
+++ b/src/ralph/models/xapi/base/ifi.py
@@ -1,7 +1,8 @@
 """Base xAPI `Inverse Functional Identifier` definitions."""
 
+from typing import Annotated
+
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ralph.conf import NonEmptyStrictStr
 

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -3,9 +3,8 @@
 # Nota bene: we split object definitions into `objects.py` and `unnested_objects.py`
 # because of the circular dependency : objects -> context -> objects.
 
-import sys
 from datetime import datetime
-from typing import Union
+from typing import Literal, Union
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -15,11 +14,6 @@ from .groups import BaseXapiGroup
 from .results import BaseXapiResult
 from .unnested_objects import BaseXapiUnnestedObject
 from .verbs import BaseXapiVerb
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class BaseXapiSubStatement(BaseModelWithConfig):

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -5,7 +5,7 @@
 
 import sys
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Union
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -32,14 +32,14 @@ class BaseXapiSubStatement(BaseModelWithConfig):
         objectType (dict): Consists of the value `SubStatement`.
     """
 
-    actor: Union[BaseXapiAgent, BaseXapiGroup]
+    actor: BaseXapiAgent | BaseXapiGroup
     verb: BaseXapiVerb
     object: BaseXapiUnnestedObject
     objectType: Literal["SubStatement"]
-    result: Optional[BaseXapiResult] = None
-    context: Optional[BaseXapiContext] = None
-    timestamp: Optional[datetime] = None
-    attachments: Optional[List[BaseXapiAttachment]] = None
+    result: BaseXapiResult | None = None
+    context: BaseXapiContext | None = None
+    timestamp: datetime | None = None
+    attachments: list[BaseXapiAttachment] | None = None
 
 
 BaseXapiObject = Union[

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -37,8 +37,5 @@ class BaseXapiSubStatement(BaseModelWithConfig):
 
 
 BaseXapiObject = (
-    BaseXapiUnnestedObject
-    | BaseXapiSubStatement
-    | BaseXapiAgent
-    | BaseXapiGroup
+    BaseXapiUnnestedObject | BaseXapiSubStatement | BaseXapiAgent | BaseXapiGroup
 )

--- a/src/ralph/models/xapi/base/objects.py
+++ b/src/ralph/models/xapi/base/objects.py
@@ -4,7 +4,7 @@
 # because of the circular dependency : objects -> context -> objects.
 
 from datetime import datetime
-from typing import Literal, Union
+from typing import Literal
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -36,9 +36,9 @@ class BaseXapiSubStatement(BaseModelWithConfig):
     attachments: list[BaseXapiAttachment] | None = None
 
 
-BaseXapiObject = Union[
-    BaseXapiUnnestedObject,
-    BaseXapiSubStatement,
-    BaseXapiAgent,
-    BaseXapiGroup,
-]
+BaseXapiObject = (
+    BaseXapiUnnestedObject
+    | BaseXapiSubStatement
+    | BaseXapiAgent
+    | BaseXapiGroup
+)

--- a/src/ralph/models/xapi/base/results.py
+++ b/src/ralph/models/xapi/base/results.py
@@ -2,10 +2,9 @@
 
 from datetime import timedelta
 from decimal import Decimal
-from typing import Any, Dict, Optional, Union
+from typing import Annotated, Any
 
 from pydantic import Field, StrictBool, model_validator
-from typing_extensions import Annotated
 
 from ralph.conf import NonEmptyStrictStr
 
@@ -23,10 +22,10 @@ class BaseXapiResultScore(BaseModelWithConfig):
         max (Decimal): Consists of the highest possible score.
     """
 
-    scaled: Optional[Annotated[Decimal, Field(ge=-1, le=1)]] = None
-    raw: Optional[Decimal] = None
-    min: Optional[Decimal] = None
-    max: Optional[Decimal] = None
+    scaled: Annotated[Decimal, Field(ge=-1, le=1)] | None = None
+    raw: Decimal | None = None
+    min: Decimal | None = None
+    max: Decimal | None = None
 
     @model_validator(mode="after")
     def check_raw_min_max_relation(self) -> Any:
@@ -55,9 +54,9 @@ class BaseXapiResult(BaseModelWithConfig):
         extensions (dict): Consists of a dictionary of other properties as needed.
     """
 
-    score: Optional[BaseXapiResultScore] = None
-    success: Optional[StrictBool] = None
-    completion: Optional[StrictBool] = None
-    response: Optional[NonEmptyStrictStr] = None
-    duration: Optional[timedelta] = None
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None
+    score: BaseXapiResultScore | None = None
+    success: StrictBool | None = None
+    completion: StrictBool | None = None
+    response: NonEmptyStrictStr | None = None
+    duration: timedelta | None = None
+    extensions: dict[IRI, str | int | bool | list | dict | None] | None = None

--- a/src/ralph/models/xapi/base/statements.py
+++ b/src/ralph/models/xapi/base/statements.py
@@ -1,11 +1,11 @@
 """Base xAPI `Statement` definitions."""
 
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import Annotated, Any
 from uuid import UUID
 
 from pydantic import StringConstraints, model_validator
-from typing_extensions import Annotated
 
 from ..config import BaseModelWithConfig
 from .agents import BaseXapiAgent
@@ -34,17 +34,17 @@ class BaseXapiStatement(BaseModelWithConfig):
         attachments (list): Consists of a list of attachments.
     """
 
-    id: Optional[UUID] = None
-    actor: Union[BaseXapiAgent, BaseXapiGroup]
+    id: UUID | None = None
+    actor: BaseXapiAgent | BaseXapiGroup
     verb: BaseXapiVerb
     object: BaseXapiObject
-    result: Optional[BaseXapiResult] = None
-    context: Optional[BaseXapiContext] = None
-    timestamp: Optional[datetime] = None
-    stored: Optional[datetime] = None
-    authority: Optional[Union[BaseXapiAgent, BaseXapiGroup]] = None
+    result: BaseXapiResult | None = None
+    context: BaseXapiContext | None = None
+    timestamp: datetime | None = None
+    stored: datetime | None = None
+    authority: BaseXapiAgent | BaseXapiGroup | None = None
     version: Annotated[str, StringConstraints(pattern=r"^1\.0\.[0-9]+$")] = "1.0.0"
-    attachments: Optional[List[BaseXapiAttachment]] = None
+    attachments: list[BaseXapiAttachment] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -57,7 +57,7 @@ class BaseXapiStatement(BaseModelWithConfig):
         for field, value in list(values.items()):
             if value in [None, "", {}]:
                 raise ValueError(f"{field}: invalid empty value")
-            if isinstance(value, dict) and field != "extensions":
+            if isinstance(value, Mapping) and field != "extensions":
                 cls.check_absence_of_empty_and_invalid_values(value)
 
         context = dict(values.get("context", {}))

--- a/src/ralph/models/xapi/base/unnested_objects.py
+++ b/src/ralph/models/xapi/base/unnested_objects.py
@@ -1,10 +1,10 @@
 """Base xAPI `Object` definitions (1)."""
 
-from typing import Any, Dict, List, Literal, Optional, Union
+from collections.abc import Sequence
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import AnyUrl, StringConstraints, field_validator
-from typing_extensions import Annotated
 
 from ralph.conf import NonEmptyStrictStr
 
@@ -23,11 +23,11 @@ class BaseXapiActivityDefinition(BaseModelWithConfig):
         extensions (dict): Consists of a dictionary of other properties as needed.
     """
 
-    name: Optional[LanguageMap] = None
-    description: Optional[LanguageMap] = None
-    type: Optional[IRI] = None
-    moreInfo: Optional[AnyUrl] = None
-    extensions: Optional[Dict[IRI, Union[str, int, bool, list, dict, None]]] = None
+    name: LanguageMap | None = None
+    description: LanguageMap | None = None
+    type: IRI | None = None
+    moreInfo: AnyUrl | None = None
+    extensions: dict[IRI, str | int | bool | list | dict | None] | None = None
 
 
 class BaseXapiInteractionComponent(BaseModelWithConfig):
@@ -39,7 +39,7 @@ class BaseXapiInteractionComponent(BaseModelWithConfig):
     """
 
     id: Annotated[str, StringConstraints(pattern=r"^[^\s]+$")]
-    description: Optional[LanguageMap] = None
+    description: LanguageMap | None = None
 
 
 class BaseXapiActivityInteractionDefinition(BaseXapiActivityDefinition):
@@ -69,16 +69,16 @@ class BaseXapiActivityInteractionDefinition(BaseXapiActivityDefinition):
         "numeric",
         "other",
     ]
-    correctResponsesPattern: Optional[List[NonEmptyStrictStr]] = None
-    choices: Optional[List[BaseXapiInteractionComponent]] = None
-    scale: Optional[List[BaseXapiInteractionComponent]] = None
-    source: Optional[List[BaseXapiInteractionComponent]] = None
-    target: Optional[List[BaseXapiInteractionComponent]] = None
-    steps: Optional[List[BaseXapiInteractionComponent]] = None
+    correctResponsesPattern: list[NonEmptyStrictStr] | None = None
+    choices: list[BaseXapiInteractionComponent] | None = None
+    scale: list[BaseXapiInteractionComponent] | None = None
+    source: list[BaseXapiInteractionComponent] | None = None
+    target: list[BaseXapiInteractionComponent] | None = None
+    steps: list[BaseXapiInteractionComponent] | None = None
 
     @field_validator("choices", "scale", "source", "target", "steps", mode="after")
     @classmethod
-    def check_unique_ids(cls, value: Optional[List[Any]]) -> None:
+    def check_unique_ids(cls, value: Sequence[Any] | None) -> None:
         """Check the uniqueness of interaction components IDs."""
         if value and (len(value) != len({x.id for x in value if x})):
             raise ValueError("Duplicate InteractionComponents are not valid")
@@ -95,13 +95,10 @@ class BaseXapiActivity(BaseModelWithConfig):
     """
 
     id: IRI
-    objectType: Optional[Literal["Activity"]] = None
-    definition: Optional[
-        Union[
-            BaseXapiActivityDefinition,
-            BaseXapiActivityInteractionDefinition,
-        ]
-    ] = None
+    objectType: Literal["Activity"] | None = None
+    definition: (
+        BaseXapiActivityDefinition | BaseXapiActivityInteractionDefinition | None
+    ) = None
 
 
 class BaseXapiStatementRef(BaseModelWithConfig):
@@ -116,4 +113,4 @@ class BaseXapiStatementRef(BaseModelWithConfig):
     objectType: Literal["StatementRef"]
 
 
-BaseXapiUnnestedObject = Union[BaseXapiActivity, BaseXapiStatementRef]
+BaseXapiUnnestedObject = BaseXapiActivity | BaseXapiStatementRef

--- a/src/ralph/models/xapi/base/verbs.py
+++ b/src/ralph/models/xapi/base/verbs.py
@@ -1,7 +1,5 @@
 """Base xAPI `Verb` definitions."""
 
-from typing import Optional
-
 from ..config import BaseModelWithConfig
 from .common import IRI, LanguageMap
 
@@ -15,4 +13,4 @@ class BaseXapiVerb(BaseModelWithConfig):
     """
 
     id: IRI
-    display: Optional[LanguageMap] = None
+    display: LanguageMap | None = None

--- a/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/activity_types/acrossx_profile.py
@@ -1,14 +1,8 @@
 """`AcrossX Profile` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Message
 

--- a/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/activity_streams_vocabulary.py
@@ -1,14 +1,8 @@
 """`Activity streams vocabulary` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Page
 

--- a/src/ralph/models/xapi/concepts/activity_types/audio.py
+++ b/src/ralph/models/xapi/concepts/activity_types/audio.py
@@ -1,14 +1,8 @@
 """`Audio` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Audio
 

--- a/src/ralph/models/xapi/concepts/activity_types/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/activity_types/scorm_profile.py
@@ -1,14 +1,8 @@
 """`Scorm Profile` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # CMI Interaction
 

--- a/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/activity_types/tincan_vocabulary.py
@@ -1,14 +1,8 @@
 """`Scorm Profile` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Document
 

--- a/src/ralph/models/xapi/concepts/activity_types/video.py
+++ b/src/ralph/models/xapi/concepts/activity_types/video.py
@@ -1,14 +1,8 @@
 """`Video` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Video
 

--- a/src/ralph/models/xapi/concepts/activity_types/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/activity_types/virtual_classroom.py
@@ -1,14 +1,8 @@
 """`Virtual classroom` activity types definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.unnested_objects import BaseXapiActivity, BaseXapiActivityDefinition
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Virtual classroom
 

--- a/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
@@ -1,7 +1,6 @@
 """`AcrossX Profile` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,4 +22,4 @@ class PostedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/acrossx/verbs/posted"] = (
         "https://w3id.org/xapi/acrossx/verbs/posted"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["posted"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/acrossx_profile.py
@@ -1,14 +1,9 @@
 """`AcrossX Profile` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class PostedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
@@ -1,14 +1,9 @@
 """`Activity streams vocabulary` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class JoinVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/activity_streams_vocabulary.py
@@ -1,7 +1,6 @@
 """`Activity streams vocabulary` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -21,7 +20,7 @@ class JoinVerb(BaseXapiVerb):
     """
 
     id: Literal["http://activitystrea.ms/join"] = "http://activitystrea.ms/join"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["joined"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["joined"]] | None = None
 
 
 class LeaveVerb(BaseXapiVerb):
@@ -33,4 +32,4 @@ class LeaveVerb(BaseXapiVerb):
     """
 
     id: Literal["http://activitystrea.ms/leave"] = "http://activitystrea.ms/leave"
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["left"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["left"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
@@ -1,7 +1,6 @@
 """`ADL Vocabulary` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,7 +22,7 @@ class AskedVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/asked"] = (
         "http://adlnet.gov/expapi/verbs/asked"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["asked"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["asked"]] | None = None
 
 
 class AnsweredVerb(BaseXapiVerb):
@@ -37,7 +36,7 @@ class AnsweredVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/answered"] = (
         "http://adlnet.gov/expapi/verbs/answered"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["answered"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["answered"]] | None = None
 
 
 class RegisteredVerb(BaseXapiVerb):
@@ -51,4 +50,4 @@ class RegisteredVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/registered"] = (
         "http://adlnet.gov/expapi/verbs/registered"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["registered"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["registered"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/adl_vocabulary.py
@@ -1,14 +1,9 @@
 """`ADL Vocabulary` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class AskedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
@@ -1,14 +1,9 @@
 """`Navy Common Reference Profile` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class AccessedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/navy_common_reference_profile.py
@@ -1,7 +1,6 @@
 """`Navy Common Reference Profile` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,7 +22,7 @@ class AccessedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/netc/verbs/accessed"] = (
         "https://w3id.org/xapi/netc/verbs/accessed"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["accessed"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["accessed"]] | None = None
 
 
 class UploadedVerb(BaseXapiVerb):
@@ -37,4 +36,4 @@ class UploadedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/netc/verbs/uploaded"] = (
         "https://w3id.org/xapi/netc/verbs/uploaded"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["uploaded"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["uploaded"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
@@ -1,7 +1,6 @@
 """`Scorm Profile` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,7 +22,7 @@ class CompletedVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/completed"] = (
         "http://adlnet.gov/expapi/verbs/completed"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["completed"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["completed"]] | None = None
 
 
 class InitializedVerb(BaseXapiVerb):
@@ -37,7 +36,7 @@ class InitializedVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/initialized"] = (
         "http://adlnet.gov/expapi/verbs/initialized"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["initialized"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["initialized"]] | None = None
 
 
 class InteractedVerb(BaseXapiVerb):
@@ -51,7 +50,7 @@ class InteractedVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/interacted"] = (
         "http://adlnet.gov/expapi/verbs/interacted"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["interacted"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["interacted"]] | None = None
 
 
 class TerminatedVerb(BaseXapiVerb):
@@ -65,4 +64,4 @@ class TerminatedVerb(BaseXapiVerb):
     id: Literal["http://adlnet.gov/expapi/verbs/terminated"] = (
         "http://adlnet.gov/expapi/verbs/terminated"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["terminated"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["terminated"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
@@ -1,14 +1,9 @@
 """`Scorm Profile` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class CompletedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
+++ b/src/ralph/models/xapi/concepts/verbs/scorm_profile.py
@@ -25,7 +25,7 @@ class InitializedVerb(BaseXapiVerb):
 
     Attributes:
         id (str): Consists of the value `http://adlnet.gov/expapi/verbs/initialized`.
-        display (Dict): Consists of the dictionary `{"en-US": "initialized"}`.
+        display (dict): Consists of the dictionary `{"en-US": "initialized"}`.
     """
 
     id: Literal["http://adlnet.gov/expapi/verbs/initialized"] = (

--- a/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
@@ -1,7 +1,6 @@
 """`TinCan Vocabulary` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,7 +22,7 @@ class ViewedVerb(BaseXapiVerb):
     id: Literal["http://id.tincanapi.com/verb/viewed"] = (
         "http://id.tincanapi.com/verb/viewed"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["viewed"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["viewed"]] | None = None
 
 
 class DownloadedVerb(BaseXapiVerb):
@@ -37,7 +36,7 @@ class DownloadedVerb(BaseXapiVerb):
     id: Literal["http://id.tincanapi.com/verb/downloaded"] = (
         "http://id.tincanapi.com/verb/downloaded"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["downloaded"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["downloaded"]] | None = None
 
 
 class UnregisteredVerb(BaseXapiVerb):
@@ -51,4 +50,4 @@ class UnregisteredVerb(BaseXapiVerb):
     id: Literal["http://id.tincanapi.com/verb/unregistered"] = (
         "http://id.tincanapi.com/verb/unregistered"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unregistered"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["unregistered"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
+++ b/src/ralph/models/xapi/concepts/verbs/tincan_vocabulary.py
@@ -1,14 +1,9 @@
 """`TinCan Vocabulary` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class ViewedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/video.py
+++ b/src/ralph/models/xapi/concepts/verbs/video.py
@@ -1,14 +1,9 @@
 """`Video` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class PlayedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/video.py
+++ b/src/ralph/models/xapi/concepts/verbs/video.py
@@ -1,7 +1,6 @@
 """`Video` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -23,7 +22,7 @@ class PlayedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/video/verbs/played"] = (
         "https://w3id.org/xapi/video/verbs/played"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["played"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["played"]] | None = None
 
 
 class PausedVerb(BaseXapiVerb):
@@ -37,7 +36,7 @@ class PausedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/video/verbs/paused"] = (
         "https://w3id.org/xapi/video/verbs/paused"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["paused"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["paused"]] | None = None
 
 
 class SeekedVerb(BaseXapiVerb):
@@ -51,4 +50,4 @@ class SeekedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/video/verbs/seeked"] = (
         "https://w3id.org/xapi/video/verbs/seeked"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["seeked"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["seeked"]] | None = None

--- a/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
@@ -1,14 +1,9 @@
 """`Virtual classroom` verbs definitions."""
 
-import sys
+from typing import Literal
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class MutedVerb(BaseXapiVerb):

--- a/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
+++ b/src/ralph/models/xapi/concepts/verbs/virtual_classroom.py
@@ -1,7 +1,6 @@
 """`Virtual classroom` verbs definitions."""
 
 import sys
-from typing import Dict, Optional
 
 from ...base.verbs import BaseXapiVerb
 from ...constants import LANG_EN_US_DISPLAY
@@ -24,7 +23,7 @@ class MutedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/muted"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/muted"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["muted"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["muted"]] | None = None
 
 
 class UnmutedVerb(BaseXapiVerb):
@@ -39,7 +38,7 @@ class UnmutedVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/unmuted"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/unmuted"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unmuted"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["unmuted"]] | None = None
 
 
 class StartedCameraVerb(BaseXapiVerb):
@@ -54,9 +53,7 @@ class StartedCameraVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/started-camera"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/started-camera"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["started camera"]]] = (
-        None
-    )
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["started camera"]] | None = None
 
 
 class StoppedCameraVerb(BaseXapiVerb):
@@ -71,9 +68,7 @@ class StoppedCameraVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/stopped-camera"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/stopped-camera"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["stopped camera"]]] = (
-        None
-    )
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["stopped camera"]] | None = None
 
 
 class SharedScreenVerb(BaseXapiVerb):
@@ -88,9 +83,7 @@ class SharedScreenVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/shared-screen"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/shared-screen"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["shared screen"]]] = (
-        None
-    )
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["shared screen"]] | None = None
 
 
 class UnsharedScreenVerb(BaseXapiVerb):
@@ -105,9 +98,7 @@ class UnsharedScreenVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/unshared-screen"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/unshared-screen"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["unshared screen"]]] = (
-        None
-    )
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["unshared screen"]] | None = None
 
 
 class RaisedHandVerb(BaseXapiVerb):
@@ -122,7 +113,7 @@ class RaisedHandVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/raised-hand"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/raised-hand"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["raised hand"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["raised hand"]] | None = None
 
 
 class LoweredHandVerb(BaseXapiVerb):
@@ -137,4 +128,4 @@ class LoweredHandVerb(BaseXapiVerb):
     id: Literal["https://w3id.org/xapi/virtual-classroom/verbs/lowered-hand"] = (
         "https://w3id.org/xapi/virtual-classroom/verbs/lowered-hand"
     )
-    display: Optional[Dict[Literal[LANG_EN_US_DISPLAY], Literal["lowered hand"]]] = None
+    display: dict[Literal[LANG_EN_US_DISPLAY], Literal["lowered hand"]] | None = None

--- a/src/ralph/models/xapi/lms/contexts.py
+++ b/src/ralph/models/xapi/lms/contexts.py
@@ -1,12 +1,12 @@
 """LMS xAPI events context fields definitions."""
 
 import sys
+from collections.abc import Sequence
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat, PositiveInt, condecimal, field_validator
-from typing_extensions import Annotated
 
 from ..base.contexts import BaseXapiContext, BaseXapiContextContextActivities
 from ..base.unnested_objects import BaseXapiActivity
@@ -46,18 +46,13 @@ class LMSContextContextActivities(BaseXapiContextContextActivities):
         category (dict or list): see LMSProfileActivity.
     """
 
-    category: Union[
-        LMSProfileActivity, List[Union[LMSProfileActivity, BaseXapiActivity]]
-    ]
+    category: LMSProfileActivity | list[LMSProfileActivity | BaseXapiActivity]
 
     @field_validator("category")
     @classmethod
     def check_presence_of_profile_activity_category(
-        cls,
-        value: Union[
-            LMSProfileActivity, List[Union[LMSProfileActivity, BaseXapiActivity]]
-        ],
-    ) -> Union[LMSProfileActivity, List[Union[LMSProfileActivity, BaseXapiActivity]]]:
+        cls, value: LMSProfileActivity | Sequence[LMSProfileActivity | BaseXapiActivity]
+    ) -> LMSProfileActivity | list[LMSProfileActivity | BaseXapiActivity]:
         """Check that the category list contains a `LMSProfileActivity`."""
         if isinstance(value, LMSProfileActivity):
             return value
@@ -96,12 +91,12 @@ class LMSRegistrationContextExtensions(BaseExtensionModelWithConfig):
     """
 
     starting_date: Annotated[
-        Optional[datetime], Field(alias=CONTEXT_EXTENSION_STARTING_DATE)
+        datetime | None, Field(alias=CONTEXT_EXTENSION_STARTING_DATE)
     ] = None
     ending_date: Annotated[
-        Optional[datetime], Field(alias=CONTEXT_EXTENSION_ENDING_DATE)
+        datetime | None, Field(alias=CONTEXT_EXTENSION_ENDING_DATE)
     ] = None
-    role: Annotated[Optional[str], Field(alias=CONTEXT_EXTENSION_ROLE)]
+    role: Annotated[str | None, Field(alias=CONTEXT_EXTENSION_ROLE)]
 
 
 class LMSRegistrationContext(LMSContext):
@@ -114,7 +109,7 @@ class LMSRegistrationContext(LMSContext):
         extensions (dict): see LMSRegistrationContextExtensions.
     """
 
-    extensions: Optional[LMSRegistrationContextExtensions] = None
+    extensions: LMSRegistrationContextExtensions | None = None
 
 
 class LMSCommonContextExtensions(BaseExtensionModelWithConfig):
@@ -129,9 +124,7 @@ class LMSCommonContextExtensions(BaseExtensionModelWithConfig):
         session_id (uuid): ID of the active session.
     """
 
-    session_id: Annotated[Optional[UUID], Field(alias=CONTEXT_EXTENSION_SESSION_ID)] = (
-        None
-    )
+    session_id: Annotated[UUID | None, Field(alias=CONTEXT_EXTENSION_SESSION_ID)] = None
 
 
 class LMSCommonContext(LMSContext):
@@ -141,7 +134,7 @@ class LMSCommonContext(LMSContext):
         extensions (dict): See LMSCommonContextExtensions.
     """
 
-    extensions: Optional[LMSCommonContextExtensions] = None
+    extensions: LMSCommonContextExtensions | None = None
 
 
 class LMSDownloadedVideoContextExtensions(LMSCommonContextExtensions):
@@ -153,12 +146,12 @@ class LMSDownloadedVideoContextExtensions(LMSCommonContextExtensions):
     """
 
     length: Annotated[
-        Optional[condecimal(ge=0, decimal_places=3)],
+        condecimal(ge=0, decimal_places=3) | None,
         Field(alias=CONTEXT_EXTENSION_LENGTH),
     ] = None
-    quality: Annotated[
-        Optional[PositiveInt], Field(alias=CONTEXT_EXTENSION_QUALITY)
-    ] = None
+    quality: Annotated[PositiveInt | None, Field(alias=CONTEXT_EXTENSION_QUALITY)] = (
+        None
+    )
 
 
 class LMSDownloadedVideoContext(LMSContext):
@@ -168,7 +161,7 @@ class LMSDownloadedVideoContext(LMSContext):
         extensions (dict): See LMSDownloadedVideoContextExtensions.
     """
 
-    extensions: Optional[LMSDownloadedVideoContextExtensions] = None
+    extensions: LMSDownloadedVideoContextExtensions | None = None
 
 
 class LMSDownloadedAudioContextExtensions(LMSCommonContextExtensions):
@@ -179,7 +172,7 @@ class LMSDownloadedAudioContextExtensions(LMSCommonContextExtensions):
     """
 
     length: Annotated[
-        Optional[NonNegativeFloat], Field(alias=CONTEXT_EXTENSION_LENGTH)
+        NonNegativeFloat | None, Field(alias=CONTEXT_EXTENSION_LENGTH)
     ] = None
 
 
@@ -190,4 +183,4 @@ class LMSDownloadedAudioContext(LMSContext):
         extensions (dict): See LMSDownloadedAudioContextExtensions.
     """
 
-    extensions: Optional[LMSDownloadedAudioContextExtensions] = None
+    extensions: LMSDownloadedAudioContextExtensions | None = None

--- a/src/ralph/models/xapi/lms/contexts.py
+++ b/src/ralph/models/xapi/lms/contexts.py
@@ -1,9 +1,8 @@
 """LMS xAPI events context fields definitions."""
 
-import sys
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat, PositiveInt, condecimal, field_validator
@@ -22,11 +21,6 @@ from ..concepts.constants.video import (
     CONTEXT_EXTENSION_QUALITY,
 )
 from ..config import BaseExtensionModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class LMSProfileActivity(ProfileActivity):

--- a/src/ralph/models/xapi/lms/objects.py
+++ b/src/ralph/models/xapi/lms/objects.py
@@ -1,7 +1,6 @@
 """LMS xAPI events object fields definitions."""
 
-import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -15,12 +14,6 @@ from ..concepts.activity_types.activity_streams_vocabulary import (
 )
 from ..concepts.constants.acrossx_profile import ACTIVITY_EXTENSIONS_TYPE
 from ..config import BaseExtensionModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 # Page
 

--- a/src/ralph/models/xapi/lms/objects.py
+++ b/src/ralph/models/xapi/lms/objects.py
@@ -1,10 +1,9 @@
 """LMS xAPI events object fields definitions."""
 
 import sys
-from typing import Optional
+from typing import Annotated
 
 from pydantic import Field
-from typing_extensions import Annotated
 
 from ..concepts.activity_types.acrossx_profile import (
     WebpageActivity,
@@ -35,7 +34,7 @@ class LMSPageObjectDefinitionExtensions(BaseExtensionModelWithConfig):
     """
 
     type: Annotated[
-        Optional[Literal["course", "course_list", "user_space"]],
+        Literal["course", "course_list", "user_space"] | None,
         Field(alias=ACTIVITY_EXTENSIONS_TYPE),
     ] = None
 
@@ -47,7 +46,7 @@ class LMSPageObjectDefinition(WebpageActivityDefinition):
         extensions (dict): see LMSPageObjectDefinitionExtensions.
     """
 
-    extensions: Optional[LMSPageObjectDefinitionExtensions] = None
+    extensions: LMSPageObjectDefinitionExtensions | None = None
 
 
 class LMSPageObject(WebpageActivity):
@@ -80,7 +79,7 @@ class LMSFileObjectDefinition(FileActivityDefinition):
         extensions (dict): see LMSFileObjectDefinitionExtensions.
     """
 
-    extensions: Optional[LMSFileObjectDefinitionExtensions] = None
+    extensions: LMSFileObjectDefinitionExtensions | None = None
 
 
 class LMSFileObject(FileActivity):

--- a/src/ralph/models/xapi/video/contexts.py
+++ b/src/ralph/models/xapi/video/contexts.py
@@ -1,8 +1,7 @@
 """Video xAPI events context fields definitions."""
 
-import sys
 from collections.abc import Sequence
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat, field_validator
@@ -24,11 +23,6 @@ from ..concepts.constants.video import (
     CONTEXT_EXTENSION_VOLUME,
 )
 from ..config import BaseExtensionModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class VideoProfileActivity(ProfileActivity):

--- a/src/ralph/models/xapi/video/contexts.py
+++ b/src/ralph/models/xapi/video/contexts.py
@@ -1,11 +1,11 @@
 """Video xAPI events context fields definitions."""
 
 import sys
-from typing import List, Optional, Union
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import Field, NonNegativeFloat, field_validator
-from typing_extensions import Annotated
 
 from ..base.contexts import BaseXapiContext, BaseXapiContextContextActivities
 from ..base.unnested_objects import BaseXapiActivity
@@ -48,20 +48,14 @@ class VideoContextContextActivities(BaseXapiContextContextActivities):
         category (dict or list): see VideoProfileActivity.
     """
 
-    category: Union[
-        VideoProfileActivity, List[Union[VideoProfileActivity, BaseXapiActivity]]
-    ]
+    category: VideoProfileActivity | list[VideoProfileActivity | BaseXapiActivity]
 
     @field_validator("category")
     @classmethod
     def check_presence_of_profile_activity_category(
         cls,
-        value: Union[
-            VideoProfileActivity, List[Union[VideoProfileActivity, BaseXapiActivity]]
-        ],
-    ) -> Union[
-        VideoProfileActivity, List[Union[VideoProfileActivity, BaseXapiActivity]]
-    ]:
+        value: VideoProfileActivity | Sequence[VideoProfileActivity | BaseXapiActivity],
+    ) -> VideoProfileActivity | list[VideoProfileActivity | BaseXapiActivity]:
         """Check that the category list contains a `VideoProfileActivity`."""
         if isinstance(value, VideoProfileActivity):
             return value
@@ -91,7 +85,7 @@ class VideoContextExtensions(BaseExtensionModelWithConfig):
         session (uuid): Consists of the ID of the active session.
     """
 
-    session_id: Annotated[Optional[UUID], Field(alias=CONTEXT_EXTENSION_SESSION_ID)]
+    session_id: Annotated[UUID | None, Field(alias=CONTEXT_EXTENSION_SESSION_ID)]
 
 
 class VideoInitializedContextExtensions(VideoContextExtensions):
@@ -118,27 +112,23 @@ class VideoInitializedContextExtensions(VideoContextExtensions):
 
     length: Annotated[NonNegativeFloat, Field(alias=CONTEXT_EXTENSION_LENGTH)]
     ccSubtitleEnabled: Annotated[
-        Optional[bool], Field(alias=CONTEXT_EXTENSION_CC_ENABLED)
+        bool | None, Field(alias=CONTEXT_EXTENSION_CC_ENABLED)
     ] = None
     ccSubtitleLang: Annotated[
-        Optional[str], Field(alias=CONTEXT_EXTENSION_CC_SUBTITLE_LANG)
+        str | None, Field(alias=CONTEXT_EXTENSION_CC_SUBTITLE_LANG)
     ] = None
-    fullScreen: Annotated[
-        Optional[bool], Field(alias=CONTEXT_EXTENSION_FULL_SCREEN)
-    ] = None
-    screenSize: Annotated[Optional[str], Field(alias=CONTEXT_EXTENSION_SCREEN_SIZE)] = (
+    fullScreen: Annotated[bool | None, Field(alias=CONTEXT_EXTENSION_FULL_SCREEN)] = (
         None
     )
+    screenSize: Annotated[str | None, Field(alias=CONTEXT_EXTENSION_SCREEN_SIZE)] = None
     videoPlaybackSize: Annotated[
-        Optional[str], Field(alias=CONTEXT_EXTENSION_VIDEO_PLAYBACK_SIZE)
+        str | None, Field(alias=CONTEXT_EXTENSION_VIDEO_PLAYBACK_SIZE)
     ] = None
-    speed: Annotated[Optional[str], Field(alias=CONTEXT_EXTENSION_SPEED)] = None
-    userAgent: Annotated[Optional[str], Field(alias=CONTEXT_EXTENSION_USER_AGENT)] = (
-        None
-    )
-    volume: Annotated[Optional[int], Field(alias=CONTEXT_EXTENSION_VOLUME)] = None
+    speed: Annotated[str | None, Field(alias=CONTEXT_EXTENSION_SPEED)] = None
+    userAgent: Annotated[str | None, Field(alias=CONTEXT_EXTENSION_USER_AGENT)] = None
+    volume: Annotated[int | None, Field(alias=CONTEXT_EXTENSION_VOLUME)] = None
     completionThreshold: Annotated[
-        Optional[float], Field(alias=CONTEXT_EXTENSION_COMPLETION_THRESHOLD)
+        float | None, Field(alias=CONTEXT_EXTENSION_COMPLETION_THRESHOLD)
     ] = None
 
 
@@ -155,7 +145,7 @@ class VideoBrowsingContextExtensions(VideoContextExtensions):
 
     length: Annotated[NonNegativeFloat, Field(alias=CONTEXT_EXTENSION_LENGTH)]
     completionThreshold: Annotated[
-        Optional[float], Field(alias=CONTEXT_EXTENSION_COMPLETION_THRESHOLD)
+        float | None, Field(alias=CONTEXT_EXTENSION_COMPLETION_THRESHOLD)
     ] = None
 
 
@@ -216,7 +206,7 @@ class VideoPlayedContext(BaseVideoContext):
         extensions (dict): See VideoContextExtensions.
     """
 
-    extensions: Optional[VideoContextExtensions] = None
+    extensions: VideoContextExtensions | None = None
 
 
 class VideoPausedContext(BaseVideoContext):
@@ -236,7 +226,7 @@ class VideoSeekedContext(BaseVideoContext):
         extensions (dict): See VideoContextExtensions.
     """
 
-    extensions: Optional[VideoContextExtensions] = None
+    extensions: VideoContextExtensions | None = None
 
 
 class VideoCompletedContext(BaseVideoContext):

--- a/src/ralph/models/xapi/video/results.py
+++ b/src/ralph/models/xapi/video/results.py
@@ -1,8 +1,7 @@
 """Video xAPI events result fields definitions."""
 
-import sys
 from datetime import timedelta
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, NonNegativeFloat
 
@@ -16,11 +15,6 @@ from ..concepts.constants.video import (
     RESULT_EXTENSION_TIME_TO,
 )
 from ..config import BaseExtensionModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class VideoResultExtensions(BaseExtensionModelWithConfig):

--- a/src/ralph/models/xapi/video/results.py
+++ b/src/ralph/models/xapi/video/results.py
@@ -2,10 +2,9 @@
 
 import sys
 from datetime import timedelta
-from typing import Optional
+from typing import Annotated
 
 from pydantic import Field, NonNegativeFloat
-from typing_extensions import Annotated
 
 from ..base.results import BaseXapiResult
 from ..concepts.constants.video import (
@@ -36,7 +35,7 @@ class VideoResultExtensions(BaseExtensionModelWithConfig):
 
     time: Annotated[NonNegativeFloat, Field(alias=RESULT_EXTENSION_TIME)]
     playedSegments: Annotated[
-        Optional[str], Field(alias=CONTEXT_EXTENSION_PLAYED_SEGMENTS)
+        str | None, Field(alias=CONTEXT_EXTENSION_PLAYED_SEGMENTS)
     ] = None
 
 
@@ -48,7 +47,7 @@ class VideoPausedResultExtensions(VideoResultExtensions):
     """
 
     progress: Annotated[
-        Optional[NonNegativeFloat], Field(alias=RESULT_EXTENSION_PROGRESS)
+        NonNegativeFloat | None, Field(alias=RESULT_EXTENSION_PROGRESS)
     ] = None
 
 
@@ -137,8 +136,8 @@ class VideoCompletedResult(BaseXapiResult):
     """
 
     extensions: VideoCompletedResultExtensions
-    completion: Optional[Literal[True]] = None
-    duration: Optional[timedelta] = None
+    completion: Literal[True] | None = None
+    duration: timedelta | None = None
 
 
 class VideoTerminatedResult(BaseXapiResult):

--- a/src/ralph/models/xapi/virtual_classroom/contexts.py
+++ b/src/ralph/models/xapi/virtual_classroom/contexts.py
@@ -1,12 +1,12 @@
 """Virtual classroom xAPI events context fields definitions."""
 
 import sys
+from collections.abc import Sequence
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import Field, field_validator
-from typing_extensions import Annotated
 
 from ..base.contexts import BaseXapiContext, BaseXapiContextContextActivities
 from ..base.unnested_objects import BaseXapiActivity
@@ -41,23 +41,23 @@ class VirtualClassroomContextContextActivities(BaseXapiContextContextActivities)
         category (dict or list): see VirtualClassroomProfileActivity.
     """
 
-    category: Union[
-        VirtualClassroomProfileActivity,
-        List[Union[VirtualClassroomProfileActivity, BaseXapiActivity]],
-    ]
+    category: (
+        VirtualClassroomProfileActivity
+        | list[VirtualClassroomProfileActivity | BaseXapiActivity]
+    )
 
     @field_validator("category")
     @classmethod
     def check_presence_of_profile_activity_category(
         cls,
-        value: Union[
-            VirtualClassroomProfileActivity,
-            List[Union[VirtualClassroomProfileActivity, BaseXapiActivity]],
-        ],
-    ) -> Union[
-        VirtualClassroomProfileActivity,
-        List[Union[VirtualClassroomProfileActivity, BaseXapiActivity]],
-    ]:
+        value: (
+            VirtualClassroomProfileActivity
+            | Sequence[VirtualClassroomProfileActivity | BaseXapiActivity]
+        ),
+    ) -> (
+        VirtualClassroomProfileActivity
+        | list[VirtualClassroomProfileActivity | BaseXapiActivity]
+    ):
         """Check that the category list contains a `VirtualClassroomProfileActivity`."""
         if isinstance(value, VirtualClassroomProfileActivity):
             return value
@@ -105,7 +105,7 @@ class VirtualClassroomInitializedContextExtensions(VirtualClassroomContextExtens
     """
 
     planned_duration: Annotated[
-        Optional[datetime], Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
+        datetime | None, Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
     ]
 
 
@@ -131,7 +131,7 @@ class VirtualClassroomJoinedContextExtensions(VirtualClassroomContextExtensions)
     """
 
     planned_duration: Annotated[
-        Optional[datetime], Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
+        datetime | None, Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
     ]
 
 
@@ -157,7 +157,7 @@ class VirtualClassroomTerminatedContextExtensions(VirtualClassroomContextExtensi
     """
 
     planned_duration: Annotated[
-        Optional[datetime], Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
+        datetime | None, Field(alias=CONTEXT_EXTENSION_PLANNED_DURATION)
     ]
 
 
@@ -181,7 +181,7 @@ class VirtualClassroomStartedPollContextActivities(
         parent (list): see VirtualClassroomActivity.
     """  # noqa: D205
 
-    parent: Union[VirtualClassroomActivity, List[VirtualClassroomActivity]]
+    parent: VirtualClassroomActivity | list[VirtualClassroomActivity]
 
 
 class VirtualClassroomStartedPollContext(VirtualClassroomContext):
@@ -210,7 +210,7 @@ class VirtualClassroomAnsweredPollContextActivities(
         parent (list): see VirtualClassroomActivity.
     """  # noqa: D205
 
-    parent: Union[VirtualClassroomActivity, List[VirtualClassroomActivity]]
+    parent: VirtualClassroomActivity | list[VirtualClassroomActivity]
 
 
 class VirtualClassroomAnsweredPollContext(VirtualClassroomContext):
@@ -238,7 +238,7 @@ class VirtualClassroomPostedPublicMessageContextActivities(
         parent (list): see VirtualClassroomActivity.
     """  # noqa: D205
 
-    parent: Union[VirtualClassroomActivity, List[VirtualClassroomActivity]]
+    parent: VirtualClassroomActivity | list[VirtualClassroomActivity]
 
 
 class VirtualClassroomPostedPublicMessageContext(VirtualClassroomContext):

--- a/src/ralph/models/xapi/virtual_classroom/contexts.py
+++ b/src/ralph/models/xapi/virtual_classroom/contexts.py
@@ -1,9 +1,8 @@
 """Virtual classroom xAPI events context fields definitions."""
 
-import sys
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import Field, field_validator
@@ -15,11 +14,6 @@ from ..concepts.activity_types.virtual_classroom import VirtualClassroomActivity
 from ..concepts.constants.cmi5_profile import CONTEXT_EXTENSION_SESSION_ID
 from ..concepts.constants.tincan_vocabulary import CONTEXT_EXTENSION_PLANNED_DURATION
 from ..config import BaseExtensionModelWithConfig
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class VirtualClassroomProfileActivity(ProfileActivity):

--- a/src/ralph/parsers.py
+++ b/src/ralph/parsers.py
@@ -3,7 +3,8 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import BinaryIO, Generator, TextIO, Union
+from collections.abc import Generator
+from typing import BinaryIO, TextIO
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ class BaseParser(ABC):
     name = "base"
 
     @abstractmethod
-    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
+    def parse(self, input_file: TextIO | BinaryIO) -> Generator:
         """Parse GELF formatted logs (one JSON string event per row).
 
         Args:
@@ -34,7 +35,7 @@ class GELFParser(BaseParser):
 
     name = "gelf"
 
-    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
+    def parse(self, input_file: TextIO | BinaryIO) -> Generator:
         """Parse GELF formatted logs (one JSON string event per row).
 
         Args:
@@ -66,7 +67,7 @@ class ElasticSearchParser(BaseParser):
 
     name = "es"
 
-    def parse(self, input_file: Union[TextIO, BinaryIO]) -> Generator:
+    def parse(self, input_file: TextIO | BinaryIO) -> Generator:
         """Parse Elasticsearch JSON documents.
 
         Args:

--- a/src/ralph/utils.py
+++ b/src/ralph/utils.py
@@ -5,6 +5,15 @@ import datetime
 import json
 import logging
 import operator
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from functools import reduce
 from importlib import import_module
 from inspect import getmembers, isclass, iscoroutine
@@ -12,18 +21,8 @@ from itertools import islice
 from logging import Logger, getLogger
 from typing import (
     Any,
-    AsyncIterable,
-    AsyncIterator,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
     Type,
     TypeVar,
-    Union,
 )
 
 from ralph.exceptions import BackendException, UnsupportedBackendException
@@ -71,7 +70,7 @@ def import_string(dotted_path: str) -> Any:
         ) from err
 
 
-def get_backend_class(backends: Dict[str, Type], name: str) -> Any:
+def get_backend_class(backends: Mapping[str, Type], name: str) -> Any:
     """Return the backend class from available backends by its name."""
     backend_class = backends.get(name)
     if not backend_class:
@@ -82,7 +81,7 @@ def get_backend_class(backends: Dict[str, Type], name: str) -> Any:
     return backend_class
 
 
-def get_backend_instance(backend_class: Type, options: Dict) -> Any:
+def get_backend_instance(backend_class: Type, options: Mapping) -> Any:
     """Return the instantiated backend given the backend class and options."""
     prefix = f"{backend_class.name}_"
     # Filter backend-related parameters. Parameter name is supposed to start
@@ -108,7 +107,7 @@ def now() -> str:
     return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
 
-def get_dict_value_from_path(dict_: Dict, path: Sequence[str]) -> Union[Dict, None]:
+def get_dict_value_from_path(dict_: Mapping, path: Sequence[str]) -> dict | None:
     """Get a nested dictionary value.
 
     Args:
@@ -124,7 +123,7 @@ def get_dict_value_from_path(dict_: Dict, path: Sequence[str]) -> Union[Dict, No
         return None
 
 
-def set_dict_value_from_path(dict_: Dict, path: List[str], value: Any) -> None:
+def set_dict_value_from_path(dict_: Mapping, path: Sequence[str], value: Any) -> None:
     """Set a nested dictionary value.
 
     Args:
@@ -137,7 +136,7 @@ def set_dict_value_from_path(dict_: Dict, path: List[str], value: Any) -> None:
     dict_[path[-1]] = value
 
 
-async def gather_with_limited_concurrency(num_tasks: Optional[int], *tasks: Any) -> Any:
+async def gather_with_limited_concurrency(num_tasks: int | None, *tasks: Any) -> Any:
     """Gather no more than `num_tasks` tasks at time.
 
     Args:
@@ -164,7 +163,7 @@ async def gather_with_limited_concurrency(num_tasks: Optional[int], *tasks: Any)
         raise exception
 
 
-def statements_are_equivalent(statement_1: dict, statement_2: dict) -> bool:
+def statements_are_equivalent(statement_1: Mapping, statement_2: Mapping) -> bool:
     """Check if statements are equivalent.
 
     To be equivalent, they must be identical on all fields not modified on input by the
@@ -192,7 +191,7 @@ T = TypeVar("T")
 def parse_iterable_to_dict(
     raw_documents: Iterable[T],
     ignore_errors: bool,
-    parser: Callable[[T], Dict[str, Any]] = json.loads,
+    parser: Callable[[T], Mapping[str, Any]] = json.loads,
 ) -> Iterator[dict]:
     """Read the `raw_documents` Iterable and yield dictionaries."""
     for i, raw_document in enumerate(raw_documents):
@@ -210,7 +209,7 @@ def parse_iterable_to_dict(
 async def async_parse_iterable_to_dict(
     raw_documents: AsyncIterable[T],
     ignore_errors: bool,
-    parser: Callable[[T], Dict[str, Any]] = json.loads,
+    parser: Callable[[T], Mapping[str, Any]] = json.loads,
 ) -> AsyncIterator[dict]:
     """Read the `raw_documents` Iterable and yield dictionaries."""
     i = 0
@@ -229,7 +228,7 @@ async def async_parse_iterable_to_dict(
 
 
 def parse_dict_to_bytes(
-    documents: Iterable[Dict[str, Any]],
+    documents: Iterable[Mapping[str, Any]],
     encoding: str,
     ignore_errors: bool,
 ) -> Iterator[bytes]:
@@ -247,7 +246,7 @@ def parse_dict_to_bytes(
 
 
 async def async_parse_dict_to_bytes(
-    documents: AsyncIterable[Dict[str, Any]],
+    documents: AsyncIterable[Mapping[str, Any]],
     encoding: str,
     ignore_errors: bool,
 ) -> AsyncIterator[bytes]:

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, Generic, TypeVar, Union
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar, Union
 
 import pytest
 
@@ -184,7 +185,7 @@ def test_backends_data_base_get_backend_generic_argument():
     assert get_backend_generic_argument(DummyAnyBackend, 1) is None
 
     # Given a backend that does not follow type hints, the function should return None.
-    class DummyBadBackend(BaseDataBackend[Dict[dict, int], Any]):  # type: ignore
+    class DummyBadBackend(BaseDataBackend[Mapping[dict, int], Any]):  # type: ignore
         """Dummy bad backend."""
 
     assert get_backend_generic_argument(DummyBadBackend, 0) is None

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Mapping
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Union
 
 import pytest
 
@@ -193,9 +193,9 @@ def test_backends_data_base_get_backend_generic_argument():
 
     # Given a backend with type hints containing a `Union`, the function should return
     # the first item of the Union.
-    T = TypeVar("T", bound=int | str)
+    T = TypeVar("T", bound=Union[int, str])
 
-    class DummyUnionBackend(BaseDataBackend[dict | int, T]):  # type: ignore
+    class DummyUnionBackend(BaseDataBackend[Union[dict, int], T]):  # type: ignore
         """Dummy Union backend."""
 
     assert get_backend_generic_argument(DummyUnionBackend, 0) is dict

--- a/tests/backends/data/test_base.py
+++ b/tests/backends/data/test_base.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Mapping
-from typing import Any, Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
 import pytest
 
@@ -193,9 +193,9 @@ def test_backends_data_base_get_backend_generic_argument():
 
     # Given a backend with type hints containing a `Union`, the function should return
     # the first item of the Union.
-    T = TypeVar("T", bound=Union[int, str])
+    T = TypeVar("T", bound=int | str)
 
-    class DummyUnionBackend(BaseDataBackend[Union[dict, int], T]):  # type: ignore
+    class DummyUnionBackend(BaseDataBackend[dict | int, T]):  # type: ignore
         """Dummy Union backend."""
 
     assert get_backend_generic_argument(DummyUnionBackend, 0) is dict

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,7 +1,8 @@
 """Mock model generation for testing."""
 
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 from polyfactory.factories.base import BaseFactory
 from polyfactory.factories.pydantic_factory import (
@@ -37,7 +38,7 @@ from ralph.models.xapi.virtual_classroom.contexts import (
 )
 
 
-def prune(d: Any, exemptions: Optional[list] = None):
+def prune(d: Any, exemptions: Sequence | None = None):
     """Remove all empty leaves from a dict, except fo those in `exemptions`."""
 
     if exemptions is None:
@@ -65,7 +66,7 @@ class ModelFactory(PolyfactoryModelFactory[T]):
     __is_base_factory__ = True
 
     @classmethod
-    def get_provider_map(cls) -> Dict[Any, Callable[[], Any]]:
+    def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
         provider_map = super().get_provider_map()
         return provider_map
 

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -3,7 +3,7 @@
 import base64
 import json
 import os
-from typing import Optional
+from collections.abc import Mapping, Sequence
 
 import bcrypt
 import pytest
@@ -34,9 +34,9 @@ def mock_basic_auth_user(  # noqa: PLR0913
     fs_,
     username: str = "jane",
     password: str = "pwd",
-    scopes: Optional[list] = None,
-    agent: Optional[dict] = None,
-    target: Optional[str] = None,
+    scopes: Sequence | None = None,
+    agent: Mapping | None = None,
+    target: str | None = None,
 ):
     """Create a user using Basic Auth in the (fake) file system.
 
@@ -44,7 +44,7 @@ def mock_basic_auth_user(  # noqa: PLR0913
         fs_: fixture provided by pyfakefs
         username (str): username used for auth
         password (str): password used for auth
-        scopes (List[str]): list of scopes available to the user
+        scopes (list[str]): list of scopes available to the user
         agent (dict): an agent that represents the user and may be used as authority
         target (str): The target index or database to store statements into.
     """
@@ -93,7 +93,7 @@ def basic_auth_credentials(fs, user_scopes=None, agent=None, target=None):
 
     Args:
         fs: fixture provided by pyfakefs (not called in the code)
-        user_scopes (List[str]): list of scopes to associate to the user
+        user_scopes (list[str]): list of scopes to associate to the user
         agent (dict): valid Agent (per xAPI specification) representing the user
         target (str): The target index or database to store statements into.
 

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -4,12 +4,12 @@ import asyncio
 import json
 import os
 import random
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import asynccontextmanager
 from functools import lru_cache, wraps
 from multiprocessing import Process
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import boto3
 import botocore
@@ -157,7 +157,7 @@ def get_mongo_test_backend():
 def get_async_mongo_test_backend(
     connection_uri: str = MONGO_TEST_CONNECTION_URI,
     default_collection: str = MONGO_TEST_COLLECTION,
-    client_options: dict = None,
+    client_options: Mapping | None = None,
 ):
     """Return an AsyncMongoDatabase backend instance using test defaults."""
     settings = AsyncMongoLRSBackend.settings_class(
@@ -296,7 +296,7 @@ def flavor(request):
 @pytest.fixture
 def lrs_backend(
     flavor,
-) -> Callable[[Optional[str]], Union[LRSDataBackend, AsyncLRSDataBackend]]:
+) -> Callable[[str | None], LRSDataBackend | AsyncLRSDataBackend]:
     """Return the `get_lrs_test_backend` function."""
     backend_class = LRSDataBackend if flavor == "sync" else AsyncLRSDataBackend
 
@@ -322,8 +322,8 @@ def lrs_backend(
         return async_func
 
     def _get_lrs_test_backend(
-        base_url: Optional[str] = "http://fake-lrs.com",
-    ) -> Union[LRSDataBackend, AsyncLRSDataBackend]:
+        base_url: str | None = "http://fake-lrs.com",
+    ) -> LRSDataBackend | AsyncLRSDataBackend:
         """Return an (Async)LRSDataBackend backend instance using test defaults."""
         headers = {
             "X_EXPERIENCE_API_VERSION": "1.0.3",
@@ -360,7 +360,7 @@ def async_mongo_backend():
     def get_mongo_data_backend(
         connection_uri: str = MONGO_TEST_CONNECTION_URI,
         default_collection: str = MONGO_TEST_COLLECTION,
-        client_options: dict = None,
+        client_options: Mapping | None = None,
     ):
         """Return an instance of `MongoDataBackend`."""
         settings = AsyncMongoDataBackend.settings_class(
@@ -452,7 +452,7 @@ def mongo_backend():
     def get_mongo_data_backend(
         connection_uri: str = MONGO_TEST_CONNECTION_URI,
         default_collection: str = MONGO_TEST_COLLECTION,
-        client_options: dict = None,
+        client_options: Mapping | None = None,
     ):
         """Return an instance of `MongoDataBackend`."""
         settings = MongoDataBackend.settings_class(
@@ -476,7 +476,7 @@ def mongo_lrs_backend():
     def get_mongo_lrs_backend(
         connection_uri: str = MONGO_TEST_CONNECTION_URI,
         default_collection: str = MONGO_TEST_COLLECTION,
-        client_options: dict = None,
+        client_options: Mapping | None = None,
     ):
         """Return an instance of MongoLRSBackend."""
         settings = MongoLRSBackend.settings_class(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,8 +4,8 @@ import hashlib
 import random
 import time
 import uuid
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import List, Optional, Union
 from uuid import UUID
 
 from ralph.api.auth.basic import get_basic_auth_user
@@ -33,7 +33,9 @@ def string_is_uuid(string: str):
         return False
 
 
-def assert_statement_get_responses_are_equivalent(response_1: dict, response_2: dict):
+def assert_statement_get_responses_are_equivalent(
+    response_1: Mapping, response_2: Mapping
+):
     """Check that responses to GET /statements are equivalent.
 
     Check that all statements in response are equivalent, meaning that all
@@ -75,8 +77,8 @@ def mock_activity(id_: int = 0):
 def mock_agent(
     ifi: str = "mbox",
     id_: int = 1,
-    home_page_id: Optional[int] = None,
-    name: Optional[str] = None,
+    home_page_id: int | None = None,
+    name: str | None = None,
     use_object_type: bool = True,
 ):
     """Create distinct mock agents with a given Inverse Functional Identifier.
@@ -131,11 +133,11 @@ def mock_agent(
 
 
 def mock_statement(
-    id_: Optional[Union[UUID, int]] = None,
-    actor: Optional[Union[dict, int]] = None,
-    verb: Optional[Union[dict, int]] = None,
-    object: Optional[Union[dict, int]] = None,
-    timestamp: Optional[Union[str, int]] = None,
+    id_: UUID | int | None = None,
+    actor: Mapping | int | None = None,
+    verb: Mapping | int | None = None,
+    object: Mapping | int | None = None,
+    timestamp: str | int | None = None,
 ):
     """Generate fake statements with random or provided parameters.
 
@@ -220,7 +222,7 @@ def configure_env_for_mock_basic_auth(monkeypatch):
 
 
 def configure_env_for_mock_oidc_auth(
-    monkeypatch, runserver_auth_backends: List[AuthBackend] = None
+    monkeypatch, runserver_auth_backends: Sequence[AuthBackend] = None
 ):
     """Configure environment variables to simulate OIDC use."""
 

--- a/tests/models/test_converter.py
+++ b/tests/models/test_converter.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -146,7 +146,7 @@ def test_converter_convert_dict_event_with_one_conversion_item(
     class DummyBaseModel(BaseModel):
         """Dummy base model with one field."""
 
-        converted: Optional[Any] = None
+        converted: Any | None = None
 
     class DummyBaseConversionSet(BaseConversionSet):
         """Dummy implementation of abstract BaseConversionSet."""

--- a/tests/models/test_validator.py
+++ b/tests/models/test_validator.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import logging
+from collections.abc import Mapping
 
 import pytest
 from pydantic import ValidationError, create_model
@@ -213,7 +214,7 @@ def test_models_validator_validate_typing_cleanup():
 def test_models_validator_get_first_valid_model_with_match(event, models, expected):
     """Test that the `get_first_valid_model` method returns the expected model."""
 
-    def dummy_get_models(event: dict):
+    def dummy_get_models(event: Mapping):
         return models
 
     validator = Validator(ModelSelector(module="os"))
@@ -233,7 +234,7 @@ def test_models_validator_get_first_valid_model_without_match(event, models, err
     matches the given event.
     """
 
-    def dummy_get_models(event: dict):
+    def dummy_get_models(event: Mapping):
         return models
 
     validator = Validator(ModelSelector(module="os"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,10 @@
 
 import json
 import logging
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from importlib import reload
 from pathlib import Path
-from typing import Optional, Union
 
 import pytest
 from click.exceptions import BadParameter
@@ -170,11 +170,11 @@ def test_cli_help_option():
 def _gen_cli_auth_args(  # noqa: PLR0913
     username: str,
     password: str,
-    scopes: list,
+    scopes: Sequence,
     ifi_command: str,
-    ifi_value: Union[str, dict],
-    agent_name: Optional[str] = None,
-    target: Optional[str] = None,
+    ifi_value: str | dict,
+    agent_name: str | None = None,
+    target: str | None = None,
     write: bool = False,
 ):
     """Generate arguments for cli to create user."""
@@ -193,11 +193,11 @@ def _gen_cli_auth_args(  # noqa: PLR0913
 
 
 def _assert_matching_basic_auth_credentials(  # noqa: PLR0913
-    credentials: dict,
+    credentials: Mapping,
     username: str,
-    scopes: list,
+    scopes: Sequence,
     ifi_type: str,
-    ifi_value: Union[str, dict],
+    ifi_value: str | dict,
     agent_name: str = None,
     hash_: str = None,
     target: str = None,


### PR DESCRIPTION
Cette PR contient : 
- le fixe de la version de python en 3.12 
- l'actualisation du typing
- la suppression des imports dépendant de la version de python

Quelques petites explications sur les choix que j'ai fait : 

Pour les arguments de fonction, j'ai principalement choisi de remplacer `var : List` par  `var: Sequence`, et `var: Dict` par `var: Mapping` pour suivre les recommandations de la doc (https://docs.python.org/3/library/typing.html#typing.List).

Par contre, pour les types de retour de fonction, je suis resté le plus précis possible ("-> list", "-> dict" etc.).

Pour les types dans les modèles pydantic, je suis également resté le plus précis possible pour des questions de performance (https://docs.pydantic.dev/latest/concepts/performance/#sequence-vs-list-or-tuple-mapping-vs-dict).

Pour tout ce qui est list, dict, set, tuple etc. je suis passé à la nouvelle version qui ne nécessite pas d'import depuis `typing` et qui utilise le type directement.

Pour tous les types `Iterator`, `Iterable`, `Generator` etc., je les importe depuis `collections.abc` plutôt que `typing`.

J'ai remplacé les `Union[A, B]` par `A | B` et `Optional[A]` par `A | None` sauf dans les cas où ça cassait les tests ou si ça rendait la compréhension plus difficile : 

```
BaseXapiAgent = Union[
	BaseXapiAgentWithMbox,
	BaseXapiAgentWithMboxSha1Sum,
	BaseXapiAgentWithOpenId,
	BaseXapiAgentWithAccount,
]
```

